### PR TITLE
fix: removed unallowed character from script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "source": "src/index",
   "bin": {
     "rn-perf-tests": "scripts/run-tests.sh",
-    "rn-perf-tests:stability": "scripts/run-stability-tests.sh"
+    "rn-perf-stability": "scripts/run-stability-tests.sh"
   },
   "files": [
     "src",


### PR DESCRIPTION
Changed name of the bin member `rn-perf-tests:stability` to `rn-perf-stability`