### PR TITLE
fix: run Jest tests serially to reduce measurement variance

### DIFF
--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -11,4 +11,5 @@ node \
   --max-old-space-size=4096 \
   --no-expose_wasm \
   node_modules/jest/bin/jest.js \
+   --runInBand \
    --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"


### PR DESCRIPTION
Apply `--runInBand` to serially execute Jest tests in order to reduce noise. 

Note: this change affect only the "after" measurement, since the "before" measurement will not be conducted with this flag.
