### PR TITLE
feature: remove expect requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ our results to demonstrate how to set up the toolset.
 yarn add git+https://github.com/callstack-internal/reassure
 ```
 
+### ES Lint setup
+
+ES Lint might require you to have at least one `expect` statement in each of your tests. In order to avoid this requirement
+for performance tests you can add following override to your `.eslintrc` file:
+
+```
+rules: {
+  'jest/expect-expect': [
+    'error',
+    { assertFunctionNames: ['measurePerformance'] },
+  ],
+}
+```
+
 ### Adding CI step
 
 Lines below should be added right before the danger step in the CI confg file:

--- a/example/.eslintrc.js
+++ b/example/.eslintrc.js
@@ -5,5 +5,9 @@ module.exports = {
     // typescript will handle that
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
+    'jest/expect-expect': [
+      'error',
+      { assertFunctionNames: ['measurePerformance'] },
+    ],
   },
 };

--- a/example/src/__tests__/OtherTest.perf-test.tsx
+++ b/example/src/__tests__/OtherTest.perf-test.tsx
@@ -38,7 +38,6 @@ test('Other Component 10', async () => {
   };
 
   await measurePerformance(<AsyncComponent />, { scenario, runs: 10 });
-  expect(true).toBeTruthy();
 });
 
 test('Other Component 20', async () => {
@@ -51,5 +50,4 @@ test('Other Component 20', async () => {
   };
 
   await measurePerformance(<AsyncComponent />, { scenario, runs: 20 });
-  expect(true).toBeTruthy();
 });

--- a/example/src/__tests__/SlowList.perf-test.tsx
+++ b/example/src/__tests__/SlowList.perf-test.tsx
@@ -45,5 +45,4 @@ test('Async Component', async () => {
   };
 
   await measurePerformance(<AsyncComponent />, { scenario });
-  expect(true).toBeTruthy();
 });


### PR DESCRIPTION
Scope:
* Remove dummy `expect` calls in tests in example app. 
* Document how user can achieve the same effect in their setup