### PR TITLE
fix: add `TEST_RUNNER_PATH` and `TEST_RUNNER_ARGS` env variables to configure test runner

### DIFF
--- a/.changeset/plenty-beds-greet.md
+++ b/.changeset/plenty-beds-greet.md
@@ -2,4 +2,4 @@
 '@reassure/reassure-cli': minor
 ---
 
-added runner configuration options via environmental variables
+Add `TEST_RUNNER_PATH` and `TEST_RUNNER_ARGS` env variables to configure test runner

--- a/.changeset/plenty-beds-greet.md
+++ b/.changeset/plenty-beds-greet.md
@@ -1,0 +1,5 @@
+---
+'@reassure/reassure-cli': minor
+---
+
+added runner configuration options via environmental variables

--- a/README.md
+++ b/README.md
@@ -322,6 +322,19 @@ resetToDefault(): void
 
 Reset current config to the original `defaultConfig` object
 
+#### Environmental variables
+
+You can use avaialable environmental variables in order to alter your test runner settings.
+
+**`TEST_RUNNER_PATH`**: An alternative path for your test runner. Defaults to `'node_modules/.bin/jest'`
+**`TEST_RUNNER_ARGS`**: Set of arguments fed to the runner. Defaults to `'--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"'`
+
+Example:
+
+```sh
+TEST_RUNNER_PATH=myOwnPath/jest/bin yarn reassure measure
+```
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Reset current config to the original `defaultConfig` object
 
 #### Environmental variables
 
-You can use avaialable environmental variables in order to alter your test runner settings.
+You can use available environmental variables in order to alter your test runner settings.
 
 **`TEST_RUNNER_PATH`**: An alternative path for your test runner. Defaults to `'node_modules/.bin/jest'`
 **`TEST_RUNNER_ARGS`**: Set of arguments fed to the runner. Defaults to `'--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"'`

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ Reset current config to the original `defaultConfig` object
 
 You can use available environmental variables in order to alter your test runner settings.
 
-**`TEST_RUNNER_PATH`**: An alternative path for your test runner. Defaults to `'node_modules/.bin/jest'`
-**`TEST_RUNNER_ARGS`**: Set of arguments fed to the runner. Defaults to `'--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"'`
+- `TEST_RUNNER_PATH`: an alternative path for your test runner. Defaults to `'node_modules/.bin/jest'`
+- `TEST_RUNNER_ARGS`: a set of arguments fed to the runner. Defaults to `'--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"'`
 
 Example:
 

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -23,9 +23,8 @@ export function run(options: MeasureOptions) {
       '--expose-gc',
       '--no-concurrent-sweeping',
       '--max-old-space-size=4096',
-      'node_modules/.bin/jest',
-      '--runInBand',
-      '--testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"',
+      process.env.TEST_RUNNER_PATH ?? 'node_modules/.bin/jest',
+      process.env.TEST_RUNNER_ARGS ?? '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"',
     ],
     { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
   );

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -322,6 +322,19 @@ resetToDefault(): void
 
 Reset current config to the original `defaultConfig` object
 
+#### Environmental variables
+
+You can use available environmental variables in order to alter your test runner settings.
+
+- `TEST_RUNNER_PATH`: an alternative path for your test runner. Defaults to `'node_modules/.bin/jest'`
+- `TEST_RUNNER_ARGS`: a set of arguments fed to the runner. Defaults to `'--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"'`
+
+Example:
+
+```sh
+TEST_RUNNER_PATH=myOwnPath/jest/bin yarn reassure measure
+```
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.


### PR DESCRIPTION
### Changes
- Added **TEST_RUNNER_PATH** and **TEST_RUNNER_ARGS** env variables to handle runner configuration for the measure script.
- Updated the Readme file.

Related to #70 