### PR TITLE
fix: improve node flags warning message

### DIFF
--- a/packages/reassure-measure/src/output.ts
+++ b/packages/reassure-measure/src/output.ts
@@ -36,7 +36,7 @@ export function showFlagsOuputIfNeeded() {
     console.error(
       '❌ Reassure: measure code is running under incorrect Node.js configuration.\n' +
         'Performance test code should be run in Jest with certain Node.js flags to increase measurements stability.\n' +
-        'Make sure you use the public API and run it using "reassure-tests" command.'
+        'Make sure you use the Reassure CLI and run it using "reassure measure" command.'
     );
   } else if (config.verbose) {
     console.log('✅ Reassure: measure code is running under correct node flags');


### PR DESCRIPTION
### Summary

`showFlagsOuputIfNeeded` incorrectly referenced `reassure-tests` script which is no longer there. 

### Test plan

Tests pass.