### PR TITLE
feature: RTL autodiscovery

### DIFF
--- a/packages/reassure-measure/src/config.ts
+++ b/packages/reassure-measure/src/config.ts
@@ -1,8 +1,24 @@
 type Render = (component: React.ReactElement<any>) => any;
 type Cleanup = () => void;
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-const RNTL = require('@testing-library/react-native');
+let defaultRender;
+let defaultCleanup;
+
+try {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  const RNTL = require('@testing-library/react-native');
+  defaultRender = RNTL.render;
+  defaultCleanup = RNTL.cleanup;
+} catch (error) {
+  try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    const RTL = require('@testing-library/react');
+    defaultRender = RTL.render;
+    defaultCleanup = RTL.cleanup;
+  } catch (error) {
+    console.warn("Reassure: couldn't find neither @testing-library/react-native nor @testing-library/react");
+  }
+}
 
 type Config = {
   runs: number;
@@ -18,8 +34,8 @@ const defaultConfig: Config = {
   dropWorst: 1,
   outputFile: process.env.OUTPUT_FILE ?? '.reassure/current.perf',
   verbose: false,
-  render: RNTL?.render,
-  cleanup: RNTL?.cleanup,
+  render: defaultRender,
+  cleanup: defaultCleanup,
 };
 
 export let config = defaultConfig;


### PR DESCRIPTION
### Summary

Step two of web React/RTL support. Auto-discovery of RTL `render` and `cleanup. 

### Test plan

All tests pass.

This code should be enough to support React web/RTL in projects. I've got a separate branch with Vite-based React boilerplate correctly running Reassure.