### PR TITLE
Add `testingLibrary` config option

### DIFF
--- a/.changeset/ten-ducks-remain.md
+++ b/.changeset/ten-ducks-remain.md
@@ -1,0 +1,7 @@
+---
+'example-native': minor
+'@callstack/reassure-measure': minor
+'reassure': minor
+---
+
+`testingLibrary` configuration option that replaces `render` and `cleanup` options

--- a/README.md
+++ b/README.md
@@ -70,11 +70,24 @@ Using npm
 npm install --save-dev reassure
 ```
 
-You will also need a working [React Native Testing Library](https://github.com/callstack/react-native-testing-library#installation) and [Jest](https://jestjs.io/docs/getting-started) setup.
+You will also need a working [Jest](https://jestjs.io/docs/getting-started) setup as well as one of either [React Native Testing Library](https://github.com/callstack/react-native-testing-library#installation) or [React Testing Library](https://testing-library.com/docs/react-testing-library/intro).
+
+> **Note**: React Native Testing Library is fully supported, while React Testing Library in beta stage.
 
 You can check our example projects:
 - [React Native (CLI)](https://github.com/callstack/reassure/tree/main/examples/native)
 - [React Native (Expo)](https://github.com/callstack/reassure/tree/main/examples/native-expo)
+
+Reassure will try to detect which Testing Library you have installed. In case both React Native Testing Library and React Testing Library are present it will 
+warn you about that and give a precedence to React Native Testing Library. You can explicitly specify Testing Library to by used by using [`configure`](#configure-function) option:
+
+```
+configure({ testingLibrary: 'react-native' })
+// or 
+configure({ testingLibrary: 'react' })
+```
+
+You should set it in your Jest setup file and you can override it in particular test files if needed.
 
 ### Writing your first test
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,7 @@ type Config = {
   dropWorst?: number;
   outputFile?: string;
   verbose?: boolean;
-  testingLibrary?: 'react-native' | 'react'
-  render?: (component: React.ReactElement<any>) => any;
-  cleanup?: () => any;
+  testingLibrary?: 'react-native' | 'react' | { render: (component: React.ReactElement<any>) => any, cleanup: () => any }
 };
 ```
 
@@ -311,19 +309,14 @@ const defaultConfig: Config = {
   outputFile: '.reassure/current.perf',
   verbose: false,
   testingLibrary: undefined, // Will try auto-detect first RNTL, then RTL
-  render: undefined, // Will try to use render first from RNTL, then from  RTL
-  cleanup: undefined, // Will try to use render first from RNTL, then from RTL
 };
 ```
 
 **`runs`**: number of repeated runs in a series per test (allows for higher accuracy by aggregating more data). Should be handled with care.
 **`dropWorst`**: number of worst dropped results from the series per test (used to remove test run outliers)
-dropWorst
 **`outputFile`**: name of the file the records will be saved to
 **`verbose`**: make Reassure log more, e.g. for debugging purposes
-**`testingLibrary`**: where to look for `render` and `cleanup` functions, supported values `'react-native'` & `'react'`
-**`render`**: your custom `render` function used to render React components
-**`cleanup`**: your custom `cleanup` function used to cleanup after rendering React components
+**`testingLibrary`**: where to look for `render` and `cleanup` functions, supported values `'react-native'`, `'react'` or object providing custom `render` and `cleanup` functions
 
 #### `configure` function
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,9 @@ type Config = {
   dropWorst?: number;
   outputFile?: string;
   verbose?: boolean;
-  render?: typeof render;
+  testingLibrary?: 'react-native' | 'react'
+  render?: (component: React.ReactElement<any>) => any;
+  cleanup?: () => any;
 };
 ```
 
@@ -295,7 +297,9 @@ const defaultConfig: Config = {
   dropWorst: 1,
   outputFile: '.reassure/current.perf',
   verbose: false,
-  render, // render fn from RNTL
+  testingLibrary: undefined, // Will try auto-detect first RNTL, then RTL
+  render: undefined, // Will try to use render first from RNTL, then from  RTL
+  cleanup: undefined, // Will try to use render first from RNTL, then from RTL
 };
 ```
 
@@ -304,7 +308,9 @@ const defaultConfig: Config = {
 dropWorst
 **`outputFile`**: name of the file the records will be saved to
 **`verbose`**: make Reassure log more, e.g. for debugging purposes
+**`testingLibrary`**: where to look for `render` and `cleanup` functions, supported values `'react-native'` & `'react'`
 **`render`**: your custom `render` function used to render React components
+**`cleanup`**: your custom `cleanup` function used to cleanup after rendering React components
 
 #### `configure` function
 

--- a/examples/native/jest.config.js
+++ b/examples/native/jest.config.js
@@ -4,7 +4,10 @@
  */
 
 module.exports = {
-  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  setupFilesAfterEnv: [
+    '@testing-library/jest-native/extend-expect',
+    './jestSetup.js',
+  ],
   preset: '@testing-library/react-native',
   clearMocks: true,
 };

--- a/examples/native/jestSetup.js
+++ b/examples/native/jestSetup.js
@@ -1,0 +1,3 @@
+import { configure } from 'reassure';
+
+configure({ testingLibrary: 'react-native', verbose: true });

--- a/packages/reassure-measure/src/config.ts
+++ b/packages/reassure-measure/src/config.ts
@@ -1,30 +1,14 @@
-type Render = (component: React.ReactElement<any>) => any;
-type Cleanup = () => void;
+export type TestingLibrary = 'react' | 'react-native';
 
-let defaultRender;
-let defaultCleanup;
-
-try {
-  // eslint-disable-next-line import/no-extraneous-dependencies
-  const RNTL = require('@testing-library/react-native');
-  defaultRender = RNTL.render;
-  defaultCleanup = RNTL.cleanup;
-} catch (error) {
-  try {
-    // eslint-disable-next-line import/no-extraneous-dependencies
-    const RTL = require('@testing-library/react');
-    defaultRender = RTL.render;
-    defaultCleanup = RTL.cleanup;
-  } catch (error) {
-    console.warn("Reassure: couldn't find neither @testing-library/react-native nor @testing-library/react");
-  }
-}
+export type Render = (component: React.ReactElement<any>) => any;
+export type Cleanup = () => void;
 
 type Config = {
   runs: number;
   dropWorst: number;
   outputFile: string;
   verbose: boolean;
+  testingLibrary?: TestingLibrary;
   render?: Render;
   cleanup?: Cleanup;
 };
@@ -34,8 +18,9 @@ const defaultConfig: Config = {
   dropWorst: 1,
   outputFile: process.env.OUTPUT_FILE ?? '.reassure/current.perf',
   verbose: false,
-  render: defaultRender,
-  cleanup: defaultCleanup,
+  testingLibrary: undefined,
+  render: undefined,
+  cleanup: undefined,
 };
 
 export let config = defaultConfig;

--- a/packages/reassure-measure/src/config.ts
+++ b/packages/reassure-measure/src/config.ts
@@ -1,4 +1,4 @@
-export type TestingLibrary = 'react' | 'react-native';
+export type TestingLibrary = 'react' | 'react-native' | { render: Render; cleanup: Cleanup };
 
 export type Render = (component: React.ReactElement<any>) => any;
 export type Cleanup = () => void;
@@ -9,8 +9,6 @@ type Config = {
   outputFile: string;
   verbose: boolean;
   testingLibrary?: TestingLibrary;
-  render?: Render;
-  cleanup?: Cleanup;
 };
 
 const defaultConfig: Config = {
@@ -19,8 +17,6 @@ const defaultConfig: Config = {
   outputFile: process.env.OUTPUT_FILE ?? '.reassure/current.perf',
   verbose: false,
   testingLibrary: undefined,
-  render: undefined,
-  cleanup: undefined,
 };
 
 export let config = defaultConfig;

--- a/packages/reassure-measure/src/measure.tsx
+++ b/packages/reassure-measure/src/measure.tsx
@@ -3,6 +3,7 @@ import * as math from 'mathjs';
 import { config } from './config';
 import { showFlagsOuputIfNeeded, writeTestStats } from './output';
 import type { MeasureRenderResult } from './types';
+import { getCleanupFunction, getRenderFunction } from './testingLibrary';
 
 export interface MeasureOptions {
   runs?: number;
@@ -34,19 +35,8 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
 
   showFlagsOuputIfNeeded();
 
-  if (!config.render) {
-    console.error(
-      '❌ Reassure: unable to find "render" function. Do you have "@testing-library/react-native" installed?'
-    );
-    throw new Error('Unable to find "render" function');
-  }
-
-  if (!config.cleanup) {
-    console.error(
-      '❌ Reassure: unable to find "cleanup" function. Do you have "@testing-library/react-native" installed?'
-    );
-    throw new Error('Unable to find "cleanup" function');
-  }
+  const render = getRenderFunction();
+  const cleanup = getCleanupFunction();
 
   for (let i = 0; i < runs + dropWorst; i += 1) {
     let duration = 0;
@@ -62,7 +52,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
       }
     };
 
-    const screen = config.render(
+    const screen = render(
       <React.Profiler id="Test" onRender={handleRender}>
         {wrappedUi}
       </React.Profiler>
@@ -72,7 +62,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
       await scenario(screen);
     }
 
-    config.cleanup();
+    cleanup();
 
     isFinished = true;
     global.gc?.();

--- a/packages/reassure-measure/src/measure.tsx
+++ b/packages/reassure-measure/src/measure.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import * as math from 'mathjs';
 import { config } from './config';
 import { showFlagsOuputIfNeeded, writeTestStats } from './output';
+import { resolveTestingLibrary } from './testingLibrary';
 import type { MeasureRenderResult } from './types';
-import { getCleanupFunction, getRenderFunction } from './testingLibrary';
 
 export interface MeasureOptions {
   runs?: number;
@@ -35,8 +35,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
 
   showFlagsOuputIfNeeded();
 
-  const render = getRenderFunction();
-  const cleanup = getCleanupFunction();
+  const { render, cleanup } = resolveTestingLibrary();
 
   for (let i = 0; i < runs + dropWorst; i += 1) {
     let duration = 0;

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -43,7 +43,7 @@ export function getRenderFunction(): Render {
       throw new Error(`Unable to import '@testing-library/react' dependency`);
     }
 
-    if (config.verbose) console.log(`Reassure: using 'rener' function from '@testing-library/react'`);
+    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react'`);
     return RTL.render;
   }
 
@@ -60,17 +60,17 @@ export function getRenderFunction(): Render {
         `\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file.`
     );
 
-    return RNTL.cleanup;
+    return RNTL.render;
   }
 
   if (RNTL != null) {
     if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react-native'`);
-    return RNTL.cleanup;
+    return RNTL.render;
   }
 
   if (RTL != null) {
     if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react'`);
-    return RTL.cleanup;
+    return RTL.render;
   }
 
   console.error(

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -33,8 +33,7 @@ export function resolveTestingLibrary(): TestingLibraryApi {
 
   if (config.testingLibrary === 'react-native') {
     if (!RNTL) {
-      console.error(`Reassure: unable to import '@testing-library/react-native' dependency`);
-      throw new Error(`Unable to import '@testing-library/react-native' dependency`);
+      throw new Error(`Reassure: unable to import '@testing-library/react-native' dependency`);
     }
 
     if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
@@ -43,8 +42,7 @@ export function resolveTestingLibrary(): TestingLibraryApi {
 
   if (config.testingLibrary === 'react') {
     if (!RTL) {
-      console.error(`Reassure: unable to import '@testing-library/react' dependency`);
-      throw new Error(`Unable to import '@testing-library/react' dependency`);
+      throw new Error(`Reassure: unable to import '@testing-library/react' dependency`);
     }
 
     if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
@@ -61,18 +59,17 @@ export function resolveTestingLibrary(): TestingLibraryApi {
   }
 
   if (RNTL != null) {
-    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react-native'`);
+    if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
     return RNTL;
   }
 
   if (RTL != null) {
-    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react'`);
+    if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
     return RTL;
   }
 
-  console.error(
+  throw new Error(
     `Reassure: unable to import neither '@testing-library/react-native' nor '@testing-library/react'.` +
       `\nAdd either of these testing libraries to your 'package.json'`
   );
-  throw "Unable to import neither '@testing-library/react-native' nor '@testing-library/react'";
 }

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -22,33 +22,41 @@ try {
 }
 
 export function resolveTestingLibrary(): TestingLibraryApi {
-  if (
-    typeof config.testingLibrary === 'object' &&
-    typeof config.testingLibrary.render === 'function' &&
-    typeof config.testingLibrary.cleanup === 'function'
-  ) {
-    if (config.verbose) console.log(`Reassure: using custom 'render' and 'cleanup' functions to render components`);
-    return config.testingLibrary;
-  }
+  // Explicit testing library option
+  if (config.testingLibrary) {
+    if (config.testingLibrary === 'react-native') {
+      if (!RNTL) {
+        throw new Error(`Reassure: unable to import '@testing-library/react-native' dependency`);
+      }
 
-  if (config.testingLibrary === 'react-native') {
-    if (!RNTL) {
-      throw new Error(`Reassure: unable to import '@testing-library/react-native' dependency`);
+      if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
+      return RNTL;
     }
 
-    if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
-    return RNTL;
-  }
+    if (config.testingLibrary === 'react') {
+      if (!RTL) {
+        throw new Error(`Reassure: unable to import '@testing-library/react' dependency`);
+      }
 
-  if (config.testingLibrary === 'react') {
-    if (!RTL) {
-      throw new Error(`Reassure: unable to import '@testing-library/react' dependency`);
+      if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
+      return RTL;
     }
 
-    if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
-    return RTL;
+    if (
+      typeof config.testingLibrary === 'object' &&
+      typeof config.testingLibrary.render === 'function' &&
+      typeof config.testingLibrary.cleanup === 'function'
+    ) {
+      if (config.verbose) console.log(`Reassure: using custom 'render' and 'cleanup' functions to render components`);
+      return config.testingLibrary;
+    }
+
+    throw new Error(
+      `Reassure: unsupported 'testingLibrary' value. Please set 'testingLibrary' to one of following values: 'react-native', 'react' or { render, cleanup }.`
+    );
   }
 
+  // Testing library auto-detection
   if (RNTL != null && RTL != null) {
     console.warn(
       `Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default.` +

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -21,10 +21,14 @@ try {
   // Do nothing
 }
 
-export function getRenderFunction(): Render {
-  if (config.render) {
-    if (config.verbose) console.log(`Reassure: using custom 'render' function.`);
-    return config.render;
+export function resolveTestingLibrary(): TestingLibraryApi {
+  if (
+    typeof config.testingLibrary === 'object' &&
+    typeof config.testingLibrary.render === 'function' &&
+    typeof config.testingLibrary.cleanup === 'function'
+  ) {
+    if (config.verbose) console.log(`Reassure: using custom 'render' and 'cleanup' functions to render components`);
+    return config.testingLibrary;
   }
 
   if (config.testingLibrary === 'react-native') {
@@ -33,8 +37,8 @@ export function getRenderFunction(): Render {
       throw new Error(`Unable to import '@testing-library/react-native' dependency`);
     }
 
-    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react-native'`);
-    return RNTL.render;
+    if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
+    return RNTL;
   }
 
   if (config.testingLibrary === 'react') {
@@ -43,15 +47,8 @@ export function getRenderFunction(): Render {
       throw new Error(`Unable to import '@testing-library/react' dependency`);
     }
 
-    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react'`);
-    return RTL.render;
-  }
-
-  if (config.testingLibrary != null) {
-    console.error(
-      `Reassure: unsupported 'testingLibrary: "${config.testingLibrary}"' option in 'configure' call. Supported values are 'react-native' and 'react'.`
-    );
-    throw new Error(`Unsupported 'testingLibrary: "${config.testingLibrary}"' option`);
+    if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
+    return RTL;
   }
 
   if (RNTL != null && RTL != null) {
@@ -60,76 +57,17 @@ export function getRenderFunction(): Render {
         `\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file.`
     );
 
-    return RNTL.render;
+    return RNTL;
   }
 
   if (RNTL != null) {
     if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react-native'`);
-    return RNTL.render;
+    return RNTL;
   }
 
   if (RTL != null) {
     if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react'`);
-    return RTL.render;
-  }
-
-  console.error(
-    `Reassure: unable to import neither '@testing-library/react-native' nor '@testing-library/react'.` +
-      `\nAdd either of these testing libraries to your 'package.json'`
-  );
-  throw "Unable to import neither '@testing-library/react-native' nor '@testing-library/react'";
-}
-
-export function getCleanupFunction(): Cleanup {
-  if (config.cleanup) {
-    if (config.verbose) console.log(`Reassure: using custom 'cleanup' function`);
-    return config.cleanup;
-  }
-
-  if (config.testingLibrary === 'react-native') {
-    if (!RNTL) {
-      console.error(`Reassure: unable to import '@testing-library/react-native' dependency`);
-      throw new Error(`Unable to import '@testing-library/react-native' dependency`);
-    }
-
-    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react-native'`);
-    return RNTL.cleanup;
-  }
-
-  if (config.testingLibrary === 'react') {
-    if (!RTL) {
-      console.error(`Reassure: unable to import '@testing-library/react' dependency`);
-      throw new Error(`Unable to import '@testing-library/react' dependency`);
-    }
-
-    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react'`);
-    return RTL.cleanup;
-  }
-
-  if (config.testingLibrary != null) {
-    console.error(
-      `Reassure: unsupported 'testingLibrary: "${config.testingLibrary}"' option in 'configure' call. Supported values are 'react-native' and 'react'.`
-    );
-    throw new Error(`Unsupported 'testingLibrary: "${config.testingLibrary}"' option`);
-  }
-
-  if (RNTL != null && RTL != null) {
-    console.warn(
-      `Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default.` +
-        `\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file.`
-    );
-
-    return RNTL.cleanup;
-  }
-
-  if (RNTL != null) {
-    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react-native'`);
-    return RNTL.cleanup;
-  }
-
-  if (RTL != null) {
-    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react'`);
-    return RTL.cleanup;
+    return RTL;
   }
 
   console.error(

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -1,0 +1,140 @@
+import { config, Render, Cleanup } from './config';
+
+type TestingLibraryApi = {
+  render: Render;
+  cleanup: Cleanup;
+};
+
+let RNTL: TestingLibraryApi | undefined;
+try {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  RNTL = require('@testing-library/react-native');
+} catch (error) {
+  // Do nothing
+}
+
+let RTL: TestingLibraryApi | undefined;
+try {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  RTL = require('@testing-library/react');
+} catch (error) {
+  // Do nothing
+}
+
+export function getRenderFunction(): Render {
+  if (config.render) {
+    if (config.verbose) console.log(`Reassure: using custom 'render' function.`);
+    return config.render;
+  }
+
+  if (config.testingLibrary === 'react-native') {
+    if (!RNTL) {
+      console.error(`Reassure: unable to import '@testing-library/react-native' dependency`);
+      throw new Error(`Unable to import '@testing-library/react-native' dependency`);
+    }
+
+    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react-native'`);
+    return RNTL.render;
+  }
+
+  if (config.testingLibrary === 'react') {
+    if (!RTL) {
+      console.error(`Reassure: unable to import '@testing-library/react' dependency`);
+      throw new Error(`Unable to import '@testing-library/react' dependency`);
+    }
+
+    if (config.verbose) console.log(`Reassure: using 'rener' function from '@testing-library/react'`);
+    return RTL.render;
+  }
+
+  if (config.testingLibrary != null) {
+    console.error(
+      `Reassure: unsupported 'testingLibrary: "${config.testingLibrary}"' option in 'configure' call. Supported values are 'react-native' and 'react'.`
+    );
+    throw new Error(`Unsupported 'testingLibrary: "${config.testingLibrary}"' option`);
+  }
+
+  if (RNTL != null && RTL != null) {
+    console.warn(
+      `Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default.` +
+        `\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file.`
+    );
+
+    return RNTL.cleanup;
+  }
+
+  if (RNTL != null) {
+    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react-native'`);
+    return RNTL.cleanup;
+  }
+
+  if (RTL != null) {
+    if (config.verbose) console.log(`Reassure: using 'render' function from '@testing-library/react'`);
+    return RTL.cleanup;
+  }
+
+  console.error(
+    `Reassure: unable to import neither '@testing-library/react-native' nor '@testing-library/react'.` +
+      `\nAdd either of these testing libraries to your 'package.json'`
+  );
+  throw "Unable to import neither '@testing-library/react-native' nor '@testing-library/react'";
+}
+
+export function getCleanupFunction(): Cleanup {
+  if (config.cleanup) {
+    if (config.verbose) console.log(`Reassure: using custom 'cleanup' function`);
+    return config.cleanup;
+  }
+
+  if (config.testingLibrary === 'react-native') {
+    if (!RNTL) {
+      console.error(`Reassure: unable to import '@testing-library/react-native' dependency`);
+      throw new Error(`Unable to import '@testing-library/react-native' dependency`);
+    }
+
+    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react-native'`);
+    return RNTL.cleanup;
+  }
+
+  if (config.testingLibrary === 'react') {
+    if (!RTL) {
+      console.error(`Reassure: unable to import '@testing-library/react' dependency`);
+      throw new Error(`Unable to import '@testing-library/react' dependency`);
+    }
+
+    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react'`);
+    return RTL.cleanup;
+  }
+
+  if (config.testingLibrary != null) {
+    console.error(
+      `Reassure: unsupported 'testingLibrary: "${config.testingLibrary}"' option in 'configure' call. Supported values are 'react-native' and 'react'.`
+    );
+    throw new Error(`Unsupported 'testingLibrary: "${config.testingLibrary}"' option`);
+  }
+
+  if (RNTL != null && RTL != null) {
+    console.warn(
+      `Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default.` +
+        `\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file.`
+    );
+
+    return RNTL.cleanup;
+  }
+
+  if (RNTL != null) {
+    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react-native'`);
+    return RNTL.cleanup;
+  }
+
+  if (RTL != null) {
+    if (config.verbose) console.log(`Reassure: using 'cleanup' function from '@testing-library/react'`);
+    return RTL.cleanup;
+  }
+
+  console.error(
+    `Reassure: unable to import neither '@testing-library/react-native' nor '@testing-library/react'.` +
+      `\nAdd either of these testing libraries to your 'package.json'`
+  );
+  throw "Unable to import neither '@testing-library/react-native' nor '@testing-library/react'";
+}


### PR DESCRIPTION
### Summary

`testingLibrary: 'react-native' | 'react' | { render, cleanup }` configuration option. Also logging errors, warnings and messages in order to help users figure out potential issues with that option.

### Test plan

All checks & test pass.
