### PR TITLE
fix: CI build that throw 'bob not found'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install and build
-        run: yarn install && yarn build
+        run: yarn install --force && yarn build
 
       - name: Validate TypeScript
         run: yarn typescript && yarn typescript:example
@@ -64,7 +64,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install and build
-        run: yarn install && yarn build
+        run: yarn install --force && yarn build
 
       - name: Run comparative test script for example app
         run: cd examples/native && ./reassure-tests.sh


### PR DESCRIPTION
### Summary

CI build started failing during `yarn turbo run build` step:

```
@callstack/reassure-measure:build: ✔ Wrote definition files to lib/typescript
@callstack/reassure-compare:build: ✔ Wrote definition files to lib/typescript
@callstack/reassure-cli:build: cache miss, executing 24570b2370bb2be9
@callstack/reassure-cli:build: $ bob build
@callstack/reassure-cli:build: /bin/sh: 1: bob: not found
@callstack/reassure-cli:build: error Command failed with exit code 127.
@callstack/reassure-cli:build: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@callstack/reassure-cli:build: ERROR: command finished with error: command (packages/reassure-cli) yarn run build exited (127)
command (packages/reassure-cli) yarn run build exited (127)
```

Looks like deps caching error.

### Test plan

All checks pass.
