### PR TITLE
refactor: replace TouchableOpacity by Pressable

### DIFF
--- a/examples/native-expo/src/SlowList.perf-test.tsx
+++ b/examples/native-expo/src/SlowList.perf-test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, TouchableOpacity, Text } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { screen, fireEvent } from '@testing-library/react-native';
 import { measurePerformance } from 'reassure';
 import { SlowList } from './SlowList';
@@ -13,9 +13,9 @@ const AsyncComponent = () => {
 
   return (
     <View>
-      <TouchableOpacity accessibilityRole="button" onPress={handlePress}>
+      <Pressable accessibilityRole="button" onPress={handlePress}>
         <Text>Action</Text>
-      </TouchableOpacity>
+      </Pressable>
 
       <Text>Count: {count}</Text>
 

--- a/examples/native/package.json
+++ b/examples/native/package.json
@@ -30,7 +30,7 @@
     "jest": "^28.0.0",
     "metro-react-native-babel-preset": "^0.70.0",
     "react-test-renderer": "^18.2.0",
-    "reassure": "^0.4.1",
+    "reassure": "^0.4.0",
     "typescript": "^4.6.2"
   }
 }

--- a/examples/native/src/OtherTest.perf-test.tsx
+++ b/examples/native/src/OtherTest.perf-test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, TouchableOpacity, Text } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { fireEvent, RenderAPI, screen } from '@testing-library/react-native';
 import { measurePerformance } from 'reassure';
 
@@ -14,9 +14,9 @@ const AsyncComponent = () => {
 
   return (
     <View>
-      <TouchableOpacity accessibilityRole="button" onPress={handlePress}>
+      <Pressable accessibilityRole="button" onPress={handlePress}>
         <Text>Action</Text>
-      </TouchableOpacity>
+      </Pressable>
 
       <Text>Count: {count}</Text>
 

--- a/examples/native/src/SlowList.perf-test.tsx
+++ b/examples/native/src/SlowList.perf-test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, TouchableOpacity, Text } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
 import { fireEvent, screen } from '@testing-library/react-native';
 import { measurePerformance } from 'reassure';
 import { SlowList } from './SlowList';
@@ -13,9 +13,9 @@ const AsyncComponent = () => {
 
   return (
     <View>
-      <TouchableOpacity accessibilityRole="button" onPress={handlePress}>
+      <Pressable accessibilityRole="button" onPress={handlePress}>
         <Text>Action</Text>
-      </TouchableOpacity>
+      </Pressable>
 
       <Text>Count: {count}</Text>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,7 +1107,7 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -1174,29 +1174,6 @@
     eslint-plugin-react-native-a11y "^3.0.0"
     eslint-restricted-globals "^0.2.0"
     prettier "^2.4.1"
-
-"@callstack/reassure-cli@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@callstack/reassure-cli/-/reassure-cli-0.3.1.tgz#baa3827a9d03c13d72f4f25b59367c32b6c2e289"
-  integrity sha512-NvGfL/+jXfmAMjaalMNa+D0bLtSV37e7VsCyf4hBT0wZaZSt/YufRlvkf0IVeaTwGX24ZkKg0hVcoQnyiUh+lw==
-  dependencies:
-    "@callstack/reassure-compare" "0.1.2"
-    yargs "^17.5.1"
-
-"@callstack/reassure-compare@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@callstack/reassure-compare/-/reassure-compare-0.1.2.tgz#e22a124ed9d56798954d7ebae2ce7531ebda15c1"
-  integrity sha512-HVqilYz24O6m3Er7UmJgtHGzllrJ6cp8AvsWSgDoug6uQ0UQ2g33UDxmPxDiHK6SIwcNao2+nQLPyg0Ms3jisg==
-  dependencies:
-    markdown-builder "^0.9.0"
-    markdown-table "^2.0.0"
-
-"@callstack/reassure-measure@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@callstack/reassure-measure/-/reassure-measure-0.3.1.tgz#4ab64317eb90da9de8076ca61a064c6afd820906"
-  integrity sha512-A7gdyA9nfm6TZt4bQs5bfgy9SOFn8FmMdOjPojSpmpSyECXRK/7aMqqBIuwPt4jgIFFDiEFsd5w88FgsE13CTQ==
-  dependencies:
-    mathjs "^10.1.1"
 
 "@changesets/apply-release-plan@^6.0.1":
   version "6.0.1"
@@ -6137,21 +6114,6 @@ markdown-table@^2.0.0:
   dependencies:
     repeat-string "^1.0.0"
 
-mathjs@^10.1.1:
-  version "10.6.1"
-  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-10.6.1.tgz#95b34178eed65cbf7a63d35c468ad3ac912f7ddf"
-  integrity sha512-8iZp6uUKKBoCFoUHze9ydsrSji9/IOEzMhwURyoQXaLL1+ILEZnraw4KzZnUBt/XN6lPJPV+7JO94oil3AmosQ==
-  dependencies:
-    "@babel/runtime" "^7.18.3"
-    complex.js "^2.1.1"
-    decimal.js "^10.3.1"
-    escape-latex "^1.2.0"
-    fraction.js "^4.2.0"
-    javascript-natural-sort "^0.7.1"
-    seedrandom "^3.0.5"
-    tiny-emitter "^2.1.0"
-    typed-function "^2.1.0"
-
 mathjs@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-11.0.1.tgz#7fb5150ef8c427f8bcddba52a084a3d8bffda7ea"
@@ -7461,14 +7423,6 @@ readline@^1.3.0:
   resolved "https://registry.yarnpkg.com/readline/-/readline-1.3.0.tgz#c580d77ef2cfc8752b132498060dc9793a7ac01c"
   integrity sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=
 
-reassure@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/reassure/-/reassure-0.4.1.tgz#e20ef3aabdaa28018a1e5392f3e3981273560f8d"
-  integrity sha512-ajLBJqfU+k+iUmmyRZyoqNQQjBq+sHhdFpyQxJpL6tQt947vXVHdqsad3RHuuT44QtW+eCzXa6noZxexC00zrA==
-  dependencies:
-    "@callstack/reassure-cli" "0.3.1"
-    "@callstack/reassure-measure" "0.3.1"
-
 recast@^0.20.4:
   version "0.20.5"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.20.5.tgz#8e2c6c96827a1b339c634dd232957d230553ceae"
@@ -8548,11 +8502,6 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-typed-function@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-2.1.0.tgz#ded6f8a442ba8749ff3fe75bc41419c8d46ccc3f"
-  integrity sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ==
 
 typed-function@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Summary

There seems to be an issue with `TouchableOpacity` implementation from React Native that causes the random increase in render counts. Swapping `TouchableOpacity` for `Pressable` reduces the renders down again.

I've did some additional testing and it appears that the issue affects only `TouchableOpacity`, other `TouchableXxx` work fine:
- `TouchableHighlight`
- `TouchableNativeFeedback`
- `TouchableWithoutFeedback`

### Test plan

All checks pass.