### PR TITLE
chore: update changesets/cli (test if danger.js runs correctly)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.18.10",
     "@babel/runtime": "^7.12.5",
     "@callstack/eslint-config": "^12.0.0",
-    "@changesets/cli": "^2.23.2",
+    "@changesets/cli": "^2.24.2",
     "@testing-library/react": "^13.3.0",
     "@testing-library/react-native": "^11.0.0",
     "@types/jest": "^28.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,16 +1175,16 @@
     eslint-restricted-globals "^0.2.0"
     prettier "^2.4.1"
 
-"@changesets/apply-release-plan@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-6.0.1.tgz#7d7b13d4dc1f03e287bc563e029ed0bf955332a9"
-  integrity sha512-KGtai19+Uo7k8uco9m+hIPGoet9E6eZq15RIeHoivvgwwI66AC6ievbUO5h0NqGlZjBWnYJQNkuT66kvBYzxsA==
+"@changesets/apply-release-plan@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-6.0.4.tgz#c08628cf5381be1aad3de69e255c68f658b4ca1a"
+  integrity sha512-PutV/ymf8cZMqvaLe/Lh5cP3kBQ9FZl6oGQ3qRDxWD1ML+/uH3jrCE7S7Zw7IVSXkD0lnMD+1dAX7fsOJ6ZvgA==
   dependencies:
     "@babel/runtime" "^7.10.4"
-    "@changesets/config" "^2.0.1"
+    "@changesets/config" "^2.1.1"
     "@changesets/get-version-range-type" "^0.3.2"
-    "@changesets/git" "^1.3.2"
-    "@changesets/types" "^5.0.0"
+    "@changesets/git" "^1.4.1"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
     detect-indent "^6.0.0"
     fs-extra "^7.0.1"
@@ -1194,44 +1194,44 @@
     resolve-from "^5.0.0"
     semver "^5.4.1"
 
-"@changesets/assemble-release-plan@^5.1.3":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-5.1.3.tgz#b415c5db64e5a30c53aed8c1adc5ab4c4aaad283"
-  integrity sha512-I+TTkUoqvxBEuDLoJfJYKDXIJ+nyiTbVJ8KGhpXEsLq4N/ms/AStSbouJwF2d/p3cB+RCPr5+gXh31GSN4kA7w==
+"@changesets/assemble-release-plan@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.0.tgz#35158dc9b496a4c108936ae8ad776ef855795ff6"
+  integrity sha512-ewY24PEbSec2eKX0+KM7eyENA2hUUp6s4LF9p/iBxTtc+TX2Xbx5rZnlLKZkc8tpuQ3PZbyjLFXWhd1PP6SjCg==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/errors" "^0.1.4"
-    "@changesets/get-dependents-graph" "^1.3.2"
-    "@changesets/types" "^5.0.0"
+    "@changesets/get-dependents-graph" "^1.3.3"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
     semver "^5.4.1"
 
-"@changesets/changelog-git@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@changesets/changelog-git/-/changelog-git-0.1.11.tgz#80eb45d3562aba2164f25ccc31ac97b9dcd1ded3"
-  integrity sha512-sWJvAm+raRPeES9usNpZRkooeEB93lOpUN0Lmjz5vhVAb7XGIZrHEJ93155bpE1S0c4oJ5Di9ZWgzIwqhWP/Wg==
+"@changesets/changelog-git@^0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@changesets/changelog-git/-/changelog-git-0.1.12.tgz#5393f74ce9591c25d6a632c20184e92ae343db0d"
+  integrity sha512-Xv2CPjTBmwjl8l4ZyQ3xrsXZMq8WafPUpEonDpTmcb24XY8keVzt7ZSCJuDz035EiqrjmDKDhODoQ6XiHudlig==
   dependencies:
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
 
-"@changesets/cli@^2.23.2":
-  version "2.23.2"
-  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.23.2.tgz#f32d3d9388816721419cff204010b64a864c950e"
-  integrity sha512-o7CWC+mcwOmA3yK5axqHOSYPYEjX/x+nq/s9aX78AyzH1SQZa6L5HX4P9uUXibyjcKynklkmusxv8vN8+hJggA==
+"@changesets/cli@^2.24.2":
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/@changesets/cli/-/cli-2.24.2.tgz#333ad412c821b582680fbc7f0d0596ebba442c2d"
+  integrity sha512-Bya7bnxF8Sz+O25M6kseAludVsCy5nXSW9u2Lbje/XbJTyU5q/xwIiXF9aTUzVi/4jyKoKoOasx7B1/z+NJLzg==
   dependencies:
     "@babel/runtime" "^7.10.4"
-    "@changesets/apply-release-plan" "^6.0.1"
-    "@changesets/assemble-release-plan" "^5.1.3"
-    "@changesets/changelog-git" "^0.1.11"
-    "@changesets/config" "^2.0.1"
+    "@changesets/apply-release-plan" "^6.0.4"
+    "@changesets/assemble-release-plan" "^5.2.0"
+    "@changesets/changelog-git" "^0.1.12"
+    "@changesets/config" "^2.1.1"
     "@changesets/errors" "^0.1.4"
-    "@changesets/get-dependents-graph" "^1.3.2"
-    "@changesets/get-release-plan" "^3.0.10"
-    "@changesets/git" "^1.3.2"
+    "@changesets/get-dependents-graph" "^1.3.3"
+    "@changesets/get-release-plan" "^3.0.13"
+    "@changesets/git" "^1.4.1"
     "@changesets/logger" "^0.0.5"
-    "@changesets/pre" "^1.0.11"
-    "@changesets/read" "^0.5.5"
-    "@changesets/types" "^5.0.0"
-    "@changesets/write" "^0.1.8"
+    "@changesets/pre" "^1.0.12"
+    "@changesets/read" "^0.5.7"
+    "@changesets/types" "^5.1.0"
+    "@changesets/write" "^0.1.9"
     "@manypkg/get-packages" "^1.1.3"
     "@types/is-ci" "^3.0.0"
     "@types/semver" "^6.0.0"
@@ -1252,15 +1252,15 @@
     term-size "^2.1.0"
     tty-table "^4.1.5"
 
-"@changesets/config@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@changesets/config/-/config-2.0.1.tgz#9c71f01032f8b12237a18edeac2a39e6142e8a50"
-  integrity sha512-rJaQWqsjM54T7bDiCoMDcgOuY2HzyovvRs68C//C+tYgbHyjs00JcNVcScjlV47hATrNG1AI8qTD7V9bcO/1cg==
+"@changesets/config@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@changesets/config/-/config-2.1.1.tgz#96c1fec5dcccb4f6d37b56bba64e5c4f3285cca6"
+  integrity sha512-nSRINMqHpdtBpNVT9Eh9HtmLhOwOTAeSbaqKM5pRmGfsvyaROTBXV84ujF9UsWNlV71YxFbxTbeZnwXSGQlyTw==
   dependencies:
     "@changesets/errors" "^0.1.4"
-    "@changesets/get-dependents-graph" "^1.3.2"
+    "@changesets/get-dependents-graph" "^1.3.3"
     "@changesets/logger" "^0.0.5"
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
     fs-extra "^7.0.1"
     micromatch "^4.0.2"
@@ -1272,28 +1272,28 @@
   dependencies:
     extendable-error "^0.1.5"
 
-"@changesets/get-dependents-graph@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.2.tgz#f3ec7ce75f4afb6e3e4b6a87fde065f552c85998"
-  integrity sha512-tsqA6qZRB86SQuApSoDvI8yEWdyIlo/WLI4NUEdhhxLMJ0dapdeT6rUZRgSZzK1X2nv5YwR0MxQBbDAiDibKrg==
+"@changesets/get-dependents-graph@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.3.tgz#9b8011d9993979a1f039ee6ce70793c81f780fea"
+  integrity sha512-h4fHEIt6X+zbxdcznt1e8QD7xgsXRAXd2qzLlyxoRDFSa6SxJrDAUyh7ZUNdhjBU4Byvp4+6acVWVgzmTy4UNQ==
   dependencies:
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
     chalk "^2.1.0"
     fs-extra "^7.0.1"
     semver "^5.4.1"
 
-"@changesets/get-release-plan@^3.0.10":
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-3.0.10.tgz#badbea8c113c976486d2eebaa66126a7ddd7ff0c"
-  integrity sha512-QeKHeo+mX1baRy3OIHQePMPebPFymq/ZxS6Bk3Y3FXiU+pXVnjrfqARj1E4xQT5c+48u6ISqJ8tW5f3EZ1/hng==
+"@changesets/get-release-plan@^3.0.13":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@changesets/get-release-plan/-/get-release-plan-3.0.13.tgz#f5f7b67b798d1bf2d6e8e546a60c199dd09bfeaf"
+  integrity sha512-Zl/UN4FUzb5LwmzhO2STRijJT5nQCN4syPEs0p1HSIR+O2iVOzes+2yTLF2zGiOx8qPOsFx/GRSAvuhSzm+9ig==
   dependencies:
     "@babel/runtime" "^7.10.4"
-    "@changesets/assemble-release-plan" "^5.1.3"
-    "@changesets/config" "^2.0.1"
-    "@changesets/pre" "^1.0.11"
-    "@changesets/read" "^0.5.5"
-    "@changesets/types" "^5.0.0"
+    "@changesets/assemble-release-plan" "^5.2.0"
+    "@changesets/config" "^2.1.1"
+    "@changesets/pre" "^1.0.12"
+    "@changesets/read" "^0.5.7"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
 
 "@changesets/get-version-range-type@^0.3.2":
@@ -1301,14 +1301,14 @@
   resolved "https://registry.yarnpkg.com/@changesets/get-version-range-type/-/get-version-range-type-0.3.2.tgz#8131a99035edd11aa7a44c341cbb05e668618c67"
   integrity sha512-SVqwYs5pULYjYT4op21F2pVbcrca4qA/bAA3FmFXKMN7Y+HcO8sbZUTx3TAy2VXulP2FACd1aC7f2nTuqSPbqg==
 
-"@changesets/git@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@changesets/git/-/git-1.3.2.tgz#336051d9a6d965806b1bc473559a9a2cc70773a6"
-  integrity sha512-p5UL+urAg0Nnpt70DLiBe2iSsMcDubTo9fTOD/61krmcJ466MGh71OHwdAwu1xG5+NKzeysdy1joRTg8CXcEXA==
+"@changesets/git@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@changesets/git/-/git-1.4.1.tgz#3f30330d94e8bcb45c4a221f34897a29cc72cd05"
+  integrity sha512-GWwRXEqBsQ3nEYcyvY/u2xUK86EKAevSoKV/IhELoZ13caZ1A1TSak/71vyKILtzuLnFPk5mepP5HjBxr7lZ9Q==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/errors" "^0.1.4"
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
     is-subdir "^1.1.1"
     spawndamnit "^2.0.0"
@@ -1320,35 +1320,35 @@
   dependencies:
     chalk "^2.1.0"
 
-"@changesets/parse@^0.3.13":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@changesets/parse/-/parse-0.3.13.tgz#82788c1fc18da4750b07357a7a06142d0d975aa1"
-  integrity sha512-wh9Ifa0dungY6d2nMz6XxF6FZ/1I7j+mEgPAqrIyKS64nifTh1Ua82qKKMMK05CL7i4wiB2NYc3SfnnCX3RVeA==
+"@changesets/parse@^0.3.14":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@changesets/parse/-/parse-0.3.14.tgz#97321604206db2572c17a12ed37671d9ee6d5e14"
+  integrity sha512-SWnNVyC9vz61ueTbuxvA6b4HXcSx2iaWr2VEa37lPg1Vw+cEyQp7lOB219P7uow1xFfdtIEEsxbzXnqLAAaY8w==
   dependencies:
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
     js-yaml "^3.13.1"
 
-"@changesets/pre@^1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@changesets/pre/-/pre-1.0.11.tgz#46a56790fdceabd03407559bbf91340c8e83fb6a"
-  integrity sha512-CXZnt4SV9waaC9cPLm7818+SxvLKIDHUxaiTXnJYDp1c56xIexx1BNfC1yMuOdzO2a3rAIcZua5Odxr3dwSKfg==
+"@changesets/pre@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@changesets/pre/-/pre-1.0.12.tgz#1eaeef1a264b32c24d85dc15cf5445c1aa8b87c6"
+  integrity sha512-RFzWYBZx56MtgMesXjxx7ymyI829/rcIw/41hvz3VJPnY8mDscN7RJyYu7Xm7vts2Fcd+SRcO0T/Ws3I1/6J7g==
   dependencies:
     "@babel/runtime" "^7.10.4"
     "@changesets/errors" "^0.1.4"
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
     "@manypkg/get-packages" "^1.1.3"
     fs-extra "^7.0.1"
 
-"@changesets/read@^0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@changesets/read/-/read-0.5.5.tgz#9ed90ef3e9f1ba3436ba5580201854a3f4163058"
-  integrity sha512-bzonrPWc29Tsjvgh+8CqJ0apQOwWim0zheeD4ZK44ApSa/GudnZJTODtA3yNOOuQzeZmL0NUebVoHIurtIkA7w==
+"@changesets/read@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@changesets/read/-/read-0.5.7.tgz#ad2454ba8e2dfceb1230102aacffcbbe4d3d4291"
+  integrity sha512-Iteg0ccTPpkJ+qFzY97k7qqdVE5Kz30TqPo9GibpBk2g8tcLFUqf+Qd0iXPLcyhUZpPL1U6Hia1gINHNKIKx4g==
   dependencies:
     "@babel/runtime" "^7.10.4"
-    "@changesets/git" "^1.3.2"
+    "@changesets/git" "^1.4.1"
     "@changesets/logger" "^0.0.5"
-    "@changesets/parse" "^0.3.13"
-    "@changesets/types" "^5.0.0"
+    "@changesets/parse" "^0.3.14"
+    "@changesets/types" "^5.1.0"
     chalk "^2.1.0"
     fs-extra "^7.0.1"
     p-filter "^2.1.0"
@@ -1358,18 +1358,18 @@
   resolved "https://registry.yarnpkg.com/@changesets/types/-/types-4.1.0.tgz#fb8f7ca2324fd54954824e864f9a61a82cb78fe0"
   integrity sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==
 
-"@changesets/types@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-5.0.0.tgz#d5eb52d074bc0358ce47d54bca54370b907812a0"
-  integrity sha512-IT1kBLSbAgTS4WtpU6P5ko054hq12vk4tgeIFRVE7Vnm4a/wgbNvBalgiKP0MjEXbCkZbItiGQHkCGxYWR55sA==
+"@changesets/types@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@changesets/types/-/types-5.1.0.tgz#e0733b69ddc3efb68524d374d3c44f53a543c8d5"
+  integrity sha512-uUByGATZCdaPkaO9JkBsgGDjEvHyY2Sb0e/J23+cwxBi5h0fxpLF/HObggO/Fw8T2nxK6zDfJbPsdQt5RwYFJA==
 
-"@changesets/write@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@changesets/write/-/write-0.1.8.tgz#feed408f644c496bc52afc4dd1353670b4152ecb"
-  integrity sha512-oIHeFVMuP6jf0TPnKPpaFpvvAf3JBc+s2pmVChbeEgQTBTALoF51Z9kqxQfG4XONZPHZnqkmy564c7qohhhhTQ==
+"@changesets/write@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@changesets/write/-/write-0.1.9.tgz#ac9315d5985f83b251820b8a046155c14a9d21f4"
+  integrity sha512-E90ZrsrfJVOOQaP3Mm5Xd7uDwBAqq3z5paVEavTHKA8wxi7NAL8CmjgbGxSFuiP7ubnJA2BuHlrdE4z86voGOg==
   dependencies:
     "@babel/runtime" "^7.10.4"
-    "@changesets/types" "^5.0.0"
+    "@changesets/types" "^5.1.0"
     fs-extra "^7.0.1"
     human-id "^1.0.2"
     prettier "^1.19.1"


### PR DESCRIPTION
### Summary

Updating `changesets` in the same way as dependabot in order to see if danger plugins runs correctly, as it does not run for dependabot's PR. Same as #131 

### Test plan

All checks pass.