### PR TITLE
Fail the CI measure process if jest fails

### DIFF
--- a/.changeset/silver-roses-sneeze.md
+++ b/.changeset/silver-roses-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-cli': minor
+---
+
+Fail reassure if jest exits with an error

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -22,6 +22,8 @@ export function run(options: MeasureOptions) {
   const outputFile = options.baseline ? BASELINE_FILE : RESULTS_FILE;
   rmSync(outputFile, { force: true });
 
+  const testRunnerPath = process.env.TEST_RUNNER_PATH ?? 'node_modules/.bin/jest';
+
   const spawnInfo = spawnSync(
     'node',
     [
@@ -29,14 +31,16 @@ export function run(options: MeasureOptions) {
       '--expose-gc',
       '--no-concurrent-sweeping',
       '--max-old-space-size=4096',
-      process.env.TEST_RUNNER_PATH ?? 'node_modules/.bin/jest',
+      testRunnerPath,
       process.env.TEST_RUNNER_ARGS ?? '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"',
     ],
     { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
   );
 
+  console.log('');
+
   if (spawnInfo.status !== 0) {
-    console.error(`❌  Something went wrong, jest process exited with an error`);
+    console.error(`❌  Test runner (${testRunnerPath}) exited with error code ${spawnInfo.status}`);
     process.exitCode = 1;
     return;
   }

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -22,7 +22,7 @@ export function run(options: MeasureOptions) {
   const outputFile = options.baseline ? BASELINE_FILE : RESULTS_FILE;
   rmSync(outputFile, { force: true });
 
-  spawnSync(
+  const spawnInfo = spawnSync(
     'node',
     [
       '--jitless',
@@ -35,7 +35,11 @@ export function run(options: MeasureOptions) {
     { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
   );
 
-  console.log('');
+  if (spawnInfo.status !== 0) {
+    console.error(`❌  Something went wrong, jest process exited with an error`);
+    process.exitCode = 1;
+    return;
+  }
 
   if (existsSync(outputFile)) {
     console.log(`✅  Written ${measurementType} performance measurements to ${outputFile}`);

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -23,6 +23,7 @@ export function run(options: MeasureOptions) {
   rmSync(outputFile, { force: true });
 
   const testRunnerPath = process.env.TEST_RUNNER_PATH ?? 'node_modules/.bin/jest';
+  const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"';
 
   const spawnInfo = spawnSync(
     'node',
@@ -32,7 +33,7 @@ export function run(options: MeasureOptions) {
       '--no-concurrent-sweeping',
       '--max-old-space-size=4096',
       testRunnerPath,
-      process.env.TEST_RUNNER_ARGS ?? '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"',
+      testRunnerArgs,
     ],
     { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
   );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Use the exit code from the jest spawned process to fail the reassure job if jest errors out. Our performance tests were silently failing since jest was failing to properly render the components. See https://github.com/callstack/reassure/issues/171

### Test plan

I tested locally by manually throwing an error in a test and running reassure.