### PR TITLE
fix: remove unnecessary jest-native deps

### DIFF
--- a/examples/native-expo/jest.config.js
+++ b/examples/native-expo/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: '@testing-library/react-native',
-  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect', './jest-setup.js'],
+  setupFilesAfterEnv: ['./jest-setup.js'],
 };

--- a/examples/native/jest.config.js
+++ b/examples/native/jest.config.js
@@ -4,10 +4,7 @@
  */
 
 module.exports = {
-  setupFilesAfterEnv: [
-    '@testing-library/jest-native/extend-expect',
-    './jestSetup.js',
-  ],
+  setupFilesAfterEnv: ['./jestSetup.js'],
   preset: '@testing-library/react-native',
   clearMocks: true,
 };

--- a/examples/native/package.json
+++ b/examples/native/package.json
@@ -22,7 +22,6 @@
     "@babel/core": "^7.18.13",
     "@babel/runtime": "^7.12.5",
     "@callstack/eslint-config": "^13.0.2",
-    "@testing-library/jest-native": "^4.0.13",
     "@testing-library/react-native": "^11.2.0",
     "babel-jest": "^29.0.3",
     "eslint": "^8.24.0",


### PR DESCRIPTION
### Summary

Resolves #189 by removing unnecessary jest `setupFilesAfterEnv` of `@testing-library/jest-native/extend-expect`, which occurred if user did not run `yarn install` in the top level folder, as the `examples/native-expo` did not have dependency on `@testing-library/jest-native` itself.

### Test plan

All checks pass.