### PR TITLE
fix: git switch on CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,15 +174,20 @@ A simple version of such script, using branch changing approach is as follows:
 
 ```sh
 #!/usr/bin/env bash
+set -e
+
 BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
+
+# Required for `git switch` on CI
+git fetch origin
 
 # Gather baseline perf measurements
 git switch "$BASELINE_BRANCH"
 yarn install --force
-yarn reassure --baseline
+yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
 
 # Gather current perf measurements & compare results
-git switch -
+git switch --detach -
 yarn install --force
 yarn reassure --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
 ```

--- a/examples/native-expo/reassure-tests.sh
+++ b/examples/native-expo/reassure-tests.sh
@@ -4,9 +4,9 @@ BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
 # Gather baseline perf measurements
 git switch "$BASELINE_BRANCH"
 yarn install --force
-yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
+yarn reassure --baseline
 
 # Gather current perf measurements & compare results
 git switch -
 yarn install --force
-yarn reassure --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
+yarn reassure --branch

--- a/examples/native/reassure-tests.sh
+++ b/examples/native/reassure-tests.sh
@@ -27,5 +27,8 @@ git switch --detach -
 echo Rebuilding Reassure packages
 pushd ../.. && yarn install --force && yarn turbo run build && popd
 
+echo GIT BRANCH: $(git branch --show-current) END
+echo GIT COMMIT HASH: $(git rev-parse HEAD) END
+
 yarn install --force
 yarn reassure --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)

--- a/examples/native/reassure-tests.sh
+++ b/examples/native/reassure-tests.sh
@@ -4,23 +4,27 @@
 set -e
 
 # Branches are not fetched by default on CI
-git fetch
+git fetch origin
 
 BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
 
 # Gather baseline perf measurements
+echo Git: switching to baseline branch "$BASELINE_BRANCH"
 git switch "$BASELINE_BRANCH"
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
+echo Rebuilding Reassure packages
 pushd ../.. && yarn install --force && yarn turbo run build && popd
 
 yarn install --force
 yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
 
 # Gather current perf measurements & compare results
+echo Git: switching back to current branch
 git switch -
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
+echo Rebuilding Reassure packages
 pushd ../.. && yarn install --force && yarn turbo run build && popd
 
 yarn install --force

--- a/examples/native/reassure-tests.sh
+++ b/examples/native/reassure-tests.sh
@@ -21,7 +21,7 @@ yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(gi
 
 # Gather current perf measurements & compare results
 echo Git: switching back to current branch
-git switch -
+git switch --detach -
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
 echo Rebuilding Reassure packages

--- a/examples/native/reassure-tests.sh
+++ b/examples/native/reassure-tests.sh
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
-
-# Exit on first error
-set -e
-
-# Branches are not fetched by default on CI
-git fetch origin
+set -e 
 
 BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
 
+# Required for `git switch` on CI
+git fetch origin
+
 # Gather baseline perf measurements
-echo Git: switching to baseline branch "$BASELINE_BRANCH"
 git switch "$BASELINE_BRANCH"
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
@@ -20,15 +17,11 @@ yarn install --force
 yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
 
 # Gather current perf measurements & compare results
-echo Git: switching back to current branch
 git switch --detach -
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
 echo Rebuilding Reassure packages
 pushd ../.. && yarn install --force && yarn turbo run build && popd
-
-echo GIT BRANCH: $(git branch --show-current) END
-echo GIT COMMIT HASH: $(git rev-parse HEAD) END
 
 yarn install --force
 yarn reassure --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)

--- a/examples/native/reassure-tests.sh
+++ b/examples/native/reassure-tests.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Exit on first error
+set -e
+
+# Branches are not fetched by default on CI
+git fetch
+
 BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
 
 # Gather baseline perf measurements

--- a/examples/native/reassure-tests.sh
+++ b/examples/native/reassure-tests.sh
@@ -10,7 +10,6 @@ git fetch origin
 git switch "$BASELINE_BRANCH"
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
-echo Rebuilding Reassure packages
 pushd ../.. && yarn install --force && yarn turbo run build && popd
 
 yarn install --force
@@ -20,7 +19,6 @@ yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(gi
 git switch --detach -
 
 # Next line is required because Reassure packages are imported from this monorepo and might require rebuilding.
-echo Rebuilding Reassure packages
 pushd ../.. && yarn install --force && yarn turbo run build && popd
 
 yarn install --force

--- a/examples/web-vite/reassure-tests.sh
+++ b/examples/web-vite/reassure-tests.sh
@@ -4,9 +4,9 @@ BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
 # Gather baseline perf measurements
 git switch "$BASELINE_BRANCH"
 yarn
-yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
+yarn reassure --baseline
 
 # Gather current perf measurements & compare results
 git switch -
 yarn
-yarn reassure --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
+yarn reassure

--- a/packages/reassure-compare/src/types.ts
+++ b/packages/reassure-compare/src/types.ts
@@ -11,8 +11,8 @@ export interface PerformanceHeader {
 
 /** Metadata information for performance results. */
 export interface PerformanceMetadata {
-  branch: string;
-  commitHash: string;
+  branch?: string;
+  commitHash?: string;
 }
 
 /** Entry in the performance results file. */

--- a/packages/reassure-compare/src/utils/format.ts
+++ b/packages/reassure-compare/src/utils/format.ts
@@ -103,5 +103,5 @@ export function formatMetadata(metadata?: PerformanceMetadata) {
     return `${metadata.branch} (${metadata.commitHash})`;
   }
 
-  return metadata?.branch ?? metadata?.commitHash ?? '(unknown)';
+  return metadata?.branch || metadata?.commitHash || '(unknown)';
 }

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -174,7 +174,12 @@ A simple version of such script, using branch changing approach is as follows:
 
 ```sh
 #!/usr/bin/env bash
+set -e
+
 BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
+
+# Required for `git switch` on CI
+git fetch origin
 
 # Gather baseline perf measurements
 git switch "$BASELINE_BRANCH"
@@ -182,7 +187,7 @@ yarn install --force
 yarn reassure --baseline --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
 
 # Gather current perf measurements & compare results
-git switch -
+git switch --detach -
 yarn install --force
 yarn reassure --branch $(git branch --show-current) --commitHash $(git rev-parse HEAD)
 ```


### PR DESCRIPTION
### Summary

`git switch main` run as part of `reassure-tests.sh` silently fails, as local git is has not been fetched from original

### Test plan

Analyse GH actions logs to confirm that the test is passing.
