### PR TITLE
fix: TEST_RUNNER_PATH not being applied

### DIFF
--- a/.changeset/metal-laws-knock.md
+++ b/.changeset/metal-laws-knock.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-cli': patch
+---
+
+fix: handling of TEST_RUNNER_PATH env variable

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -36,11 +36,11 @@ export async function run(options: MeasureOptions) {
   const header = { metadata };
   writeFileSync(outputFile, JSON.stringify(header) + '\n');
 
-  const defaultTestRunnerPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
-  const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultTestRunnerPath;
+  const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
+  const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultPath;
 
-  const defaultTestRunnerArgs = '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"';
-  const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? defaultTestRunnerArgs;
+  const defaultArgs = '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"';
+  const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? defaultArgs;
 
   const spawnInfo = spawnSync(
     'node',

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -36,12 +36,11 @@ export async function run(options: MeasureOptions) {
   const header = { metadata };
   writeFileSync(outputFile, JSON.stringify(header) + '\n');
 
-  const testRunnerPath =
-    process.env.TEST_RUNNER_PATH ?? process.platform === 'win32'
-      ? 'node_modules/jest/bin/jest'
-      : 'node_modules/.bin/jest';
+  const defaultTestRunnerPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
+  const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultTestRunnerPath;
 
-  const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"';
+  const defaultTestRunnerArgs = '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"';
+  const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? defaultTestRunnerArgs;
 
   const spawnInfo = spawnSync(
     'node',


### PR DESCRIPTION
### Summary

`TEST_RUNNER_PATH` was not applied due to incorrect usage of operator priorities.  

Resolves #324 

### Test plan

All checks run correctly.