### PR TITLE
Added support for passing a custom `--testMatch` option to Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ test('Simple test', async () => {
 
 This test will measure render times of `ComponentUnderTest` during mounting and resulting sync effects.
 
-> **Note**: Reassure will automatically match test filenames using Jest's `--testMatch` option with value `"<rootDir>/**/*.perf-test.[jt]s?(x)"`.
+> **Note**: Reassure will automatically match test filenames using Jest's `--testMatch` option with value `"<rootDir>/**/*.perf-test.[jt]s?(x)"`. However, if you would like to pass a custom `--testMatch` option, you may add it to the `reassure measure` script in order to pass your own glob. More about `--testMatch` in [Jest docs](https://jestjs.io/docs/configuration#testmatch-arraystring)
 
 #### Writing async tests
 

--- a/docusaurus/docs/installation.md
+++ b/docusaurus/docs/installation.md
@@ -52,7 +52,7 @@ test('Simple test', async () => {
 
 This test will measure render times of `ComponentUnderTest` during mounting and resulting sync effects.
 
-> **Note**: Reassure will automatically match test filenames using Jest's `--testMatch` option with value `"<rootDir>/**/*.perf-test.[jt]s?(x)"`.
+> **Note**: Reassure will automatically match test filenames using Jest's `--testMatch` option with value `"<rootDir>/**/*.perf-test.[jt]s?(x)"`. However, if you would like to pass a custom `--testMatch` option, you may add it to the `reassure measure` script in order to pass your own glob. More about `--testMatch` in [Jest docs](https://jestjs.io/docs/configuration#testmatch-arraystring)
 
 ### Writing async tests
 

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -45,10 +45,18 @@ export async function run(options: MeasureOptions) {
   const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
   const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultPath;
 
-  const defaultMatchPattern = '**/*.perf-test.[jt]s?(x)';
-  const testRunnerMatchPattern = options.testMatch || defaultMatchPattern;
+  // NOTE: Consider updating the default testMatch to better reflect
+  // default patterns used in Jest and allow users to also place their
+  // performance tests into specific /__perf__/ directory without the need
+  // of adding the *.perf-test. prefix
+  // ---
+  // [ **/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]
+  // ---
+  // GH: https://github.com/callstack/reassure/issues/363
+  const defaultTestMatch = '**/*.perf-test.[jt]s?(x)';
+  const testMatch = options.testMatch || defaultTestMatch;
 
-  const defaultArgs = `--runInBand --testMatch "<rootDir>/${testRunnerMatchPattern}"`;
+  const defaultArgs = `--runInBand --testMatch "<rootDir>/${testMatch}"`;
   const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? defaultArgs;
 
   const nodeArgs = [

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -138,7 +138,6 @@ export const command: CommandModule<{}, MeasureOptions> = {
         describe: 'Commit hash of current code to be included in the report',
       })
       .option('testMatch', {
-        alias: 'tm',
         type: 'string',
         default: undefined,
         describe: 'Run performance tests for a specific test file',

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -18,6 +18,7 @@ interface MeasureOptions extends CommonOptions {
   compare?: boolean;
   branch?: string;
   commitHash?: string;
+  testMatch?: string;
 }
 
 export async function run(options: MeasureOptions) {
@@ -44,9 +45,10 @@ export async function run(options: MeasureOptions) {
   const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
   const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultPath;
 
-  const defaultArgs = `--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)" ${
-    options.silent ? '--silent' : ''
-  }`;
+  const defaultMatchPattern = '**/*.perf-test.[jt]s?(x)';
+  const testRunnerMatchPattern = options.testMatch || defaultMatchPattern;
+
+  const defaultArgs = `--runInBand --testMatch "<rootDir>/${testRunnerMatchPattern}"`;
   const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? defaultArgs;
 
   const nodeArgs = [
@@ -127,8 +129,8 @@ export const command: CommandModule<{}, MeasureOptions> = {
         type: 'string',
         describe: 'Commit hash of current code to be included in the report',
       })
-      .option('file', {
-        alias: 'f',
+      .option('testMatch', {
+        alias: 'tm',
         type: 'string',
         default: undefined,
         describe: 'Run performance tests for a specific test file',

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -126,6 +126,12 @@ export const command: CommandModule<{}, MeasureOptions> = {
       .option('commit-hash', {
         type: 'string',
         describe: 'Commit hash of current code to be included in the report',
+      })
+      .option('file', {
+        alias: 'f',
+        type: 'string',
+        default: undefined,
+        describe: 'Run performance tests for a specific test file',
       });
   },
   handler: (args) => run(args),


### PR DESCRIPTION
### Summary

Resolves: https://github.com/callstack/reassure/issues/314

- Added new option to `yarn reassure measure` and subsequently - `yarn reassure` commands: `--file | -f`
- Added validation for the option by checking whether provided file exists
- Fallback to default if file does not exist

**Important**
Using `TEST_RUNNER_ARGS` will override this feature as it works by adjusting the `defaultArgs` string

### Test plan

1. Clone repo
2. run `yarn`
3. run `yarn reassure -f "examples/native/src/OtherTest.perf-test.tsx"`

Result: Only one test is ran

### Demo

https://user-images.githubusercontent.com/18323849/217242592-9d221c06-944c-45f9-bbcf-accdd63a7589.mov

