### PR TITLE
feat: logger

### DIFF
--- a/packages/reassure-cli/package.json
+++ b/packages/reassure-cli/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/callstack/reassure#readme",
   "dependencies": {
     "@callstack/reassure-compare": "0.3.0",
+    "@callstack/reassure-logger": "0.1.0",
     "simple-git": "^3.16.0",
     "yargs": "^17.6.2"
   },

--- a/packages/reassure-cli/src/commands/check-stability.ts
+++ b/packages/reassure-cli/src/commands/check-stability.ts
@@ -1,7 +1,11 @@
 import type { CommandModule } from 'yargs';
+import { applyCommonOptions, CommonOptions } from '../options';
+import { configureLoggerOptions } from '../utils/logger';
 import { run as measure } from './measure';
 
-export async function run() {
+export async function run(options: CommonOptions) {
+  configureLoggerOptions(options);
+
   await measure({ baseline: true });
   await measure({ baseline: false, compare: true });
 }
@@ -9,5 +13,8 @@ export async function run() {
 export const command: CommandModule = {
   command: 'check-stability',
   describe: 'Checks how stable is the current machine by running measurements twice for the same code',
-  handler: () => run(),
+  builder: (yargs) => {
+    return applyCommonOptions(yargs);
+  },
+  handler: (args) => run(args),
 };

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -5,6 +5,7 @@ import type { CommandModule } from 'yargs';
 import { compare, formatMetadata } from '@callstack/reassure-compare';
 import type { PerformanceMetadata } from '@callstack/reassure-compare/lib/typescript/types';
 import { getGitBranch, getGitCommitHash } from '../utils/git';
+import * as Logger from '../utils/logger';
 
 const RESULTS_DIRECTORY = '.reassure';
 const RESULTS_FILE = '.reassure/current.perf';
@@ -25,8 +26,8 @@ export async function run(options: MeasureOptions) {
     commitHash: options?.commitHash ?? (await getGitCommitHash()),
   };
 
-  console.log(`\n❇️  Running performance tests:`);
-  console.log(` - ${measurementType}: ${formatMetadata(metadata)}\n`);
+  Logger.log(`\n❇️  Running performance tests:`);
+  Logger.log(` - ${measurementType}: ${formatMetadata(metadata)}\n`);
 
   mkdirSync(RESULTS_DIRECTORY, { recursive: true });
 
@@ -55,7 +56,7 @@ export async function run(options: MeasureOptions) {
     { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
   );
 
-  console.log('');
+  Logger.log('');
 
   if (spawnInfo.status !== 0) {
     console.error(`❌  Test runner (${testRunnerPath}) exited with error code ${spawnInfo.status}`);
@@ -64,15 +65,15 @@ export async function run(options: MeasureOptions) {
   }
 
   if (existsSync(outputFile)) {
-    console.log(`✅  Written ${measurementType} performance measurements to ${outputFile}`);
-    console.log(`🔗 ${resolve(outputFile)}\n`);
+    Logger.log(`✅  Written ${measurementType} performance measurements to ${outputFile}`);
+    Logger.log(`🔗 ${resolve(outputFile)}\n`);
   } else {
-    console.error(`❌  Something went wrong, ${measurementType} performance file (${outputFile}) does not exist\n`);
+    Logger.error(`❌  Something went wrong, ${measurementType} performance file (${outputFile}) does not exist\n`);
     return;
   }
 
   if (options.baseline) {
-    console.log("Hint: You can now run 'reassure' to measure & compare performance against modified code.\n");
+    Logger.log("Hint: You can now run 'reassure' to measure & compare performance against modified code.\n");
     return;
   }
 
@@ -80,7 +81,7 @@ export async function run(options: MeasureOptions) {
     if (existsSync(BASELINE_FILE)) {
       compare();
     } else {
-      console.log(
+      Logger.log(
         `Baseline performance file does not exist, run 'reassure --baseline' on your baseline code branch to create it.\n`
       );
       return;

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -5,7 +5,7 @@ import type { CommandModule } from 'yargs';
 import { compare, formatMetadata } from '@callstack/reassure-compare';
 import type { PerformanceMetadata } from '@callstack/reassure-compare/lib/typescript/types';
 import { getGitBranch, getGitCommitHash } from '../utils/git';
-import * as Logger from '../utils/logger';
+import { logger } from '../utils/logger';
 
 const RESULTS_DIRECTORY = '.reassure';
 const RESULTS_FILE = '.reassure/current.perf';
@@ -26,8 +26,9 @@ export async function run(options: MeasureOptions) {
     commitHash: options?.commitHash ?? (await getGitCommitHash()),
   };
 
-  Logger.log(`\n❇️  Running performance tests:`);
-  Logger.log(` - ${measurementType}: ${formatMetadata(metadata)}\n`);
+  logger.log('');
+  logger.log(`❇️  Running performance tests:`);
+  logger.log(` - ${measurementType}: ${formatMetadata(metadata)}\n`);
 
   mkdirSync(RESULTS_DIRECTORY, { recursive: true });
 
@@ -56,7 +57,7 @@ export async function run(options: MeasureOptions) {
     { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
   );
 
-  Logger.log('');
+  logger.log('');
 
   if (spawnInfo.status !== 0) {
     console.error(`❌  Test runner (${testRunnerPath}) exited with error code ${spawnInfo.status}`);
@@ -65,15 +66,15 @@ export async function run(options: MeasureOptions) {
   }
 
   if (existsSync(outputFile)) {
-    Logger.log(`✅  Written ${measurementType} performance measurements to ${outputFile}`);
-    Logger.log(`🔗 ${resolve(outputFile)}\n`);
+    logger.log(`✅  Written ${measurementType} performance measurements to ${outputFile}`);
+    logger.log(`🔗 ${resolve(outputFile)}\n`);
   } else {
-    Logger.error(`❌  Something went wrong, ${measurementType} performance file (${outputFile}) does not exist\n`);
+    logger.error(`❌  Something went wrong, ${measurementType} performance file (${outputFile}) does not exist\n`);
     return;
   }
 
   if (options.baseline) {
-    Logger.log("Hint: You can now run 'reassure' to measure & compare performance against modified code.\n");
+    logger.log("Hint: You can now run 'reassure' to measure & compare performance against modified code.\n");
     return;
   }
 
@@ -81,7 +82,7 @@ export async function run(options: MeasureOptions) {
     if (existsSync(BASELINE_FILE)) {
       compare();
     } else {
-      Logger.log(
+      logger.log(
         `Baseline performance file does not exist, run 'reassure --baseline' on your baseline code branch to create it.\n`
       );
       return;

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -57,7 +57,16 @@ export async function run(options: MeasureOptions) {
       testRunnerPath,
       testRunnerArgs,
     ],
-    { shell: true, stdio: 'inherit', env: { ...process.env, OUTPUT_FILE: outputFile } }
+    {
+      shell: true,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        OUTPUT_FILE: outputFile,
+        REASSURE_SILENT: options.silent.toString(),
+        REASSURE_VERBOSE: options.verbose.toString(),
+      },
+    }
   );
 
   logger.log('');

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -44,30 +44,31 @@ export async function run(options: MeasureOptions) {
   const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
   const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultPath;
 
-  const defaultArgs = '--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)"';
+  const defaultArgs = `--runInBand --testMatch "<rootDir>/**/*.perf-test.[jt]s?(x)" ${
+    options.silent ? '--silent' : ''
+  }`;
   const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? defaultArgs;
 
-  const spawnInfo = spawnSync(
-    'node',
-    [
-      '--jitless',
-      '--expose-gc',
-      '--no-concurrent-sweeping',
-      '--max-old-space-size=4096',
-      testRunnerPath,
-      testRunnerArgs,
-    ],
-    {
-      shell: true,
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        OUTPUT_FILE: outputFile,
-        REASSURE_SILENT: options.silent.toString(),
-        REASSURE_VERBOSE: options.verbose.toString(),
-      },
-    }
-  );
+  const nodeArgs = [
+    '--jitless',
+    '--expose-gc',
+    '--no-concurrent-sweeping',
+    '--max-old-space-size=4096',
+    testRunnerPath,
+    testRunnerArgs,
+  ];
+  logger.verbose('Running tests: node ', nodeArgs.join(' '));
+
+  const spawnInfo = spawnSync('node', nodeArgs, {
+    shell: true,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      OUTPUT_FILE: outputFile,
+      REASSURE_SILENT: options.silent.toString(),
+      REASSURE_VERBOSE: options.verbose.toString(),
+    },
+  });
 
   logger.log('');
 

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -4,21 +4,24 @@ import { spawnSync } from 'child_process';
 import type { CommandModule } from 'yargs';
 import { compare, formatMetadata } from '@callstack/reassure-compare';
 import type { PerformanceMetadata } from '@callstack/reassure-compare/lib/typescript/types';
+import { applyCommonOptions, CommonOptions } from '../options';
 import { getGitBranch, getGitCommitHash } from '../utils/git';
-import { logger } from '../utils/logger';
+import { configureLoggerOptions, logger } from '../utils/logger';
 
 const RESULTS_DIRECTORY = '.reassure';
 const RESULTS_FILE = '.reassure/current.perf';
 const BASELINE_FILE = '.reassure/baseline.perf';
 
-type MeasureOptions = {
+interface MeasureOptions extends CommonOptions {
   baseline?: boolean;
   compare?: boolean;
   branch?: string;
   commitHash?: string;
-};
+}
 
 export async function run(options: MeasureOptions) {
+  configureLoggerOptions(options);
+
   const measurementType = options.baseline ? 'Baseline' : 'Current';
 
   const metadata: PerformanceMetadata = {
@@ -94,7 +97,7 @@ export const command: CommandModule<{}, MeasureOptions> = {
   command: ['measure', '$0'],
   describe: 'Gather performance measurements by running performance tests',
   builder: (yargs) => {
-    return yargs
+    return applyCommonOptions(yargs)
       .option('baseline', {
         type: 'boolean',
         default: false,

--- a/packages/reassure-cli/src/options.ts
+++ b/packages/reassure-cli/src/options.ts
@@ -2,10 +2,10 @@ import type yargs from 'yargs';
 
 export interface CommonOptions {
   /** Silent all non-error messages. */
-  silent?: boolean;
+  silent: boolean;
 
   /** Show verbose-level logs. */
-  verbose?: boolean;
+  verbose: boolean;
 }
 
 export function applyCommonOptions(yargs: yargs.Argv<{}>) {

--- a/packages/reassure-cli/src/options.ts
+++ b/packages/reassure-cli/src/options.ts
@@ -1,0 +1,23 @@
+import type yargs from 'yargs';
+
+export interface CommonOptions {
+  /** Silent all non-error messages. */
+  silent?: boolean;
+
+  /** Show verbose-level logs. */
+  verbose?: boolean;
+}
+
+export function applyCommonOptions(yargs: yargs.Argv<{}>) {
+  return yargs
+    .option('silent', {
+      type: 'boolean',
+      default: false,
+      describe: 'Silences all logs except errors',
+    })
+    .option('verbose', {
+      type: 'boolean',
+      default: true,
+      describe: 'Outputs verbose level logs',
+    });
+}

--- a/packages/reassure-cli/src/utils/git.ts
+++ b/packages/reassure-cli/src/utils/git.ts
@@ -1,4 +1,5 @@
 import simpleGit from 'simple-git';
+import * as Logger from './logger';
 
 export async function getGitBranch() {
   try {
@@ -11,7 +12,7 @@ export async function getGitBranch() {
     const branch = await git.revparse(['--abbrev-ref', 'HEAD']);
     return branch.trim() ? branch : undefined;
   } catch (error) {
-    console.log('Failed to get git branch', error);
+    Logger.warn('Failed to get git branch', error);
     return undefined;
   }
 }
@@ -27,7 +28,7 @@ export async function getGitCommitHash() {
     const commitHash = await git.revparse(['HEAD']);
     return commitHash.trim() ? commitHash : undefined;
   } catch (error) {
-    console.log('Failed to get git commit hash', error);
+    Logger.warn('Failed to get git commit hash', error);
     return undefined;
   }
 }

--- a/packages/reassure-cli/src/utils/logger.ts
+++ b/packages/reassure-cli/src/utils/logger.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+
+export type LoggerOptions = {
+  /** Silent all non-error logs */
+  silent: boolean;
+
+  /** Show verbose-level logs (default not shown) */
+  verbose: boolean;
+};
+
+const colors = {
+  primary: '#4fe89a',
+  error: '#E73A0E',
+  warn: '#E7900E',
+  dim: '#919191',
+} as const;
+
+let prefix = chalk.hex(colors.primary)('reassure-cli: ');
+
+const defaultOptions: LoggerOptions = {
+  verbose: false,
+  silent: false,
+} as const;
+
+let options: LoggerOptions = { ...defaultOptions };
+
+export function configure(options: Partial<LoggerOptions>) {
+  options = { ...options, ...options };
+}
+
+export function verbose(...args: any[]) {
+  if (!options.verbose || options.silent) return;
+
+  console.log(prefix, chalk.hex(colors.dim)(args));
+}
+
+export function log(...args: any[]) {
+  if (options.silent) return;
+
+  console.log(prefix, chalk.hex(colors.dim)(args));
+}
+
+export function warn(...args: any[]) {
+  if (options.silent) return;
+
+  console.warn(prefix, chalk.hex(colors.warn)(args));
+}
+
+export function error(...args: any[]) {
+  console.error(prefix, chalk.hex(colors.error)(args));
+}

--- a/packages/reassure-cli/src/utils/logger.ts
+++ b/packages/reassure-cli/src/utils/logger.ts
@@ -1,3 +1,11 @@
-import { bindLogger } from '@callstack/reassure-logger';
+import { bindLogger, configure } from '@callstack/reassure-logger';
+import type { CommonOptions } from '../options';
 
 export const logger = bindLogger('reassure-cli');
+
+export function configureLoggerOptions(options: CommonOptions) {
+  configure({
+    silent: options.silent,
+    verbose: options.verbose,
+  });
+}

--- a/packages/reassure-compare/src/output/console.ts
+++ b/packages/reassure-compare/src/output/console.ts
@@ -7,46 +7,52 @@ import {
   formatRenderDurationChange,
 } from '../utils/format';
 import type { PerformanceMetadata } from '../types';
+import { logger } from '../utils/logger';
 
 export function printToConsole(data: CompareResult) {
   // No need to log errors or warnings as these were be logged on the fly
 
-  console.log('❇️  Performance comparison results:');
+  logger.log('❇️  Performance comparison results:');
   printMetadata('Current', data.metadata.current);
   printMetadata('Baseline', data.metadata.baseline);
 
-  console.log('\n➡️  Signficant changes to render duration');
+  logger.log('');
+  logger.log('➡️  Signficant changes to render duration');
   data.significant.forEach(printRegularLine);
 
-  console.log('\n➡️  Meaningless changes to render duration');
+  logger.log('');
+  logger.log('➡️  Meaningless changes to render duration');
   data.meaningless.forEach(printRegularLine);
 
-  console.log('\n➡️  Render count changes');
+  logger.log('');
+  logger.log('➡️  Render count changes');
   data.countChanged.forEach(printRegularLine);
 
-  console.log('\n➡️  Added scenarios');
+  logger.log('');
+  logger.log('➡️  Added scenarios');
   data.added.forEach(printAddedLine);
 
-  console.log('\n➡️  Removed scenarios');
+  logger.log('');
+  logger.log('➡️  Removed scenarios');
   data.removed.forEach(printRemovedLine);
 
-  console.log('');
+  logger.log('');
 }
 
 function printMetadata(name: string, metadata?: PerformanceMetadata) {
-  console.log(` - ${name}: ${formatMetadata(metadata)}`);
+  logger.log(` - ${name}: ${formatMetadata(metadata)}`);
 }
 
 function printRegularLine(entry: CompareEntry) {
-  console.log(` - ${entry.name}: ${formatRenderDurationChange(entry)} | ${formatRenderCountChange(entry)}`);
+  logger.log(` - ${entry.name}: ${formatRenderDurationChange(entry)} | ${formatRenderCountChange(entry)}`);
 }
 
 function printAddedLine(entry: AddedEntry) {
   const { current } = entry;
-  console.log(` - ${entry.name}: ${formatDuration(current.meanDuration)} | ${formatCount(current.meanCount)}`);
+  logger.log(` - ${entry.name}: ${formatDuration(current.meanDuration)} | ${formatCount(current.meanCount)}`);
 }
 
 function printRemovedLine(entry: RemovedEntry) {
   const { baseline } = entry;
-  console.log(` - ${entry.name}: ${formatDuration(baseline.meanDuration)} | ${formatCount(baseline.meanCount)}`);
+  logger.log(` - ${entry.name}: ${formatDuration(baseline.meanDuration)} | ${formatCount(baseline.meanCount)}`);
 }

--- a/packages/reassure-compare/src/output/json.ts
+++ b/packages/reassure-compare/src/output/json.ts
@@ -1,16 +1,17 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import type { CompareResult } from '../types';
+import { logger } from '../utils/logger';
 
 export async function writeToJson(filePath: string, data: CompareResult) {
   try {
     await fs.writeFile(filePath, JSON.stringify(data, null, 2));
 
-    console.log(`✅  Written JSON output file ${filePath}`);
-    console.log(`🔗 ${path.resolve(filePath)}\n`);
+    logger.log(`✅  Written JSON output file ${filePath}`);
+    logger.log(`🔗 ${path.resolve(filePath)}\n`);
   } catch (error) {
-    console.log(`❌  Could not write JSON output file ${filePath}`);
-    console.log(`🔗 ${path.resolve(filePath)}`);
+    logger.log(`❌  Could not write JSON output file ${filePath}`);
+    logger.log(`🔗 ${path.resolve(filePath)}`);
     console.error(error);
     throw error;
   }

--- a/packages/reassure-compare/src/output/markdown.ts
+++ b/packages/reassure-compare/src/output/markdown.ts
@@ -12,6 +12,7 @@ import {
   formatRenderCountChange,
   formatRenderDurationChange,
 } from '../utils/format';
+import { logger } from '../utils/logger';
 import type {
   AddedEntry,
   CompareEntry,
@@ -37,11 +38,11 @@ async function writeToFile(filePath: string, content: string) {
   try {
     await fs.writeFile(filePath, content);
 
-    console.log(`✅  Written output markdown output file ${filePath}`);
-    console.log(`🔗 ${path.resolve(filePath)}\n`);
+    logger.log(`✅  Written output markdown output file ${filePath}`);
+    logger.log(`🔗 ${path.resolve(filePath)}\n`);
   } catch (error) {
-    console.log(`❌  Could not write markdown output file ${filePath}`);
-    console.log(`🔗 ${path.resolve(filePath)}`);
+    logger.log(`❌  Could not write markdown output file ${filePath}`);
+    logger.log(`🔗 ${path.resolve(filePath)}`);
     console.error(error);
     throw error;
   }

--- a/packages/reassure-compare/src/utils/logger.ts
+++ b/packages/reassure-compare/src/utils/logger.ts
@@ -1,3 +1,3 @@
 import { bindLogger } from '@callstack/reassure-logger';
 
-export const logger = bindLogger('reassure-cli');
+export const logger = bindLogger('reassure-compare');

--- a/packages/reassure-logger/package.json
+++ b/packages/reassure-logger/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@callstack/reassure-compare",
-  "version": "0.3.0",
-  "description": "Performance testing companion for React and React Native",
+  "name": "@callstack/reassure-logger",
+  "version": "0.1.0",
+  "description": "Logger for Reassure project",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",
@@ -28,7 +28,6 @@
   "author": "Maciej Jastrzębski <mdjastrzebski@gmail.com> (https://github.com/mdjastrzebski)",
   "contributors": [
     "Jakub Bujko <jakub.bujko@callstack.com> (https://github.com/Xiltyn)",
-    "Tomasz Krzyżowski <tomasz.krzyzowski@callstack.com> (https://github.com/TMaszko)",
     "Michał Pierzchała <thymikee@gmail.com> (https://github.com/thymikee)"
   ],
   "license": "MIT",
@@ -37,11 +36,9 @@
   },
   "homepage": "https://github.com/callstack/reassure#readme",
   "dependencies": {
-    "@callstack/reassure-logger": "0.1.0",
-    "markdown-builder": "^0.9.0",
-    "markdown-table": "^2.0.0",
-    "zod": "^3.20.2"
+    "chalk": "4.1.2"
   },
+  "devDependencies": { },
   "react-native-builder-bob": {
     "source": "src",
     "output": "lib",
@@ -53,9 +50,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "babel-jest": "^29.3.1",
-    "ts-jest": "^29.0.5"
   }
 }

--- a/packages/reassure-logger/src/colors.ts
+++ b/packages/reassure-logger/src/colors.ts
@@ -1,0 +1,6 @@
+export const colors = {
+  primary: '#4fe89a',
+  error: '#E73A0E',
+  warn: '#E7900E',
+  dim: '#919191',
+} as const;

--- a/packages/reassure-logger/src/index.ts
+++ b/packages/reassure-logger/src/index.ts
@@ -1,0 +1,1 @@
+export { bindLogger, configure } from './logger';

--- a/packages/reassure-logger/src/logger.ts
+++ b/packages/reassure-logger/src/logger.ts
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+import { colors } from './colors';
+
+export type LoggerOptions = {
+  /** Silent all non-error logs */
+  silent: boolean;
+
+  /** Show verbose-level logs (default not shown) */
+  verbose: boolean;
+};
+
+const defaultConfig: LoggerOptions = {
+  verbose: false,
+  silent: false,
+} as const;
+
+let config: LoggerOptions = { ...defaultConfig };
+
+const colorPrimary = chalk.hex(colors.primary);
+const colorWarn = chalk.hex(colors.warn);
+const colorDim = chalk.hex(colors.dim);
+
+export function configure(options: Partial<LoggerOptions>) {
+  config = { ...config, ...options };
+}
+
+export function verbose(prefix: string, ...args: unknown[]) {
+  if (!config.verbose || config.silent) return;
+
+  console.log(colorPrimary(prefix), colorDim(...args));
+}
+
+export function log(prefix: string, ...args: unknown[]) {
+  if (config.silent) return;
+
+  console.log(colorPrimary(prefix), ...args);
+}
+
+export function warn(prefix: string, ...args: unknown[]) {
+  if (config.silent) return;
+
+  console.warn(colorPrimary(prefix), colorWarn(...args));
+}
+
+export function error(prefix: string, ...args: unknown[]) {
+  console.error(colorPrimary(prefix), colorDim(...args));
+}
+
+export function bindLogger(prefix: string) {
+  return {
+    verbose: (...args: unknown[]) => verbose(prefix, ...args),
+    log: (...args: unknown[]) => log(prefix, ...args),
+    warn: (...args: unknown[]) => warn(prefix, ...args),
+    error: (...args: unknown[]) => error(prefix, ...args),
+  };
+}

--- a/packages/reassure-logger/tsconfig.json
+++ b/packages/reassure-logger/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "./",
+    "isolatedModules": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "esModuleInterop": true,
+    "importsNotUsedAsValues": "error",
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": ["esnext"],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitUseStrict": false,
+    "noStrictGenericChecks": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/reassure-measure/package.json
+++ b/packages/reassure-measure/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/callstack/reassure#readme",
   "dependencies": {
+    "@callstack/reassure-logger": "0.1.0",
     "mathjs": "^11.5.0"
   },
   "peerDependencies": {

--- a/packages/reassure-measure/src/config.ts
+++ b/packages/reassure-measure/src/config.ts
@@ -7,7 +7,6 @@ type Config = {
   runs: number;
   dropWorst: number;
   outputFile: string;
-  verbose: boolean;
   testingLibrary?: TestingLibrary;
 };
 
@@ -15,7 +14,6 @@ const defaultConfig: Config = {
   runs: 10,
   dropWorst: 1,
   outputFile: process.env.OUTPUT_FILE ?? '.reassure/current.perf',
-  verbose: false,
   testingLibrary: undefined,
 };
 

--- a/packages/reassure-measure/src/output.ts
+++ b/packages/reassure-measure/src/output.ts
@@ -35,12 +35,12 @@ export function showFlagsOuputIfNeeded() {
 
   if (!global.gc) {
     logger.error(
-      '❌ Reassure: measure code is running under incorrect Node.js configuration.\n' +
+      '❌ measure code is running under incorrect Node.js configuration.\n' +
         'Performance test code should be run in Jest with certain Node.js flags to increase measurements stability.\n' +
         'Make sure you use the Reassure CLI and run it using "reassure" command.'
     );
   } else {
-    logger.verbose('✅ Reassure: measure code is running under correct node flags');
+    logger.verbose('measure code is running under correct node flags');
   }
 
   hasShowFlagsOutput = true;

--- a/packages/reassure-measure/src/output.ts
+++ b/packages/reassure-measure/src/output.ts
@@ -35,12 +35,12 @@ export function showFlagsOuputIfNeeded() {
 
   if (!global.gc) {
     logger.error(
-      '❌ measure code is running under incorrect Node.js configuration.\n' +
+      '❌ Measure code is running under incorrect Node.js configuration.\n' +
         'Performance test code should be run in Jest with certain Node.js flags to increase measurements stability.\n' +
         'Make sure you use the Reassure CLI and run it using "reassure" command.'
     );
   } else {
-    logger.verbose('measure code is running under correct node flags');
+    logger.verbose('Measure code is running under correct node flags');
   }
 
   hasShowFlagsOutput = true;

--- a/packages/reassure-measure/src/output.ts
+++ b/packages/reassure-measure/src/output.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import { config } from './config';
+import { logger } from './utils/logger';
 import type { MeasureRenderResult } from './types';
 
 export async function writeTestStats(
@@ -33,13 +34,13 @@ export function showFlagsOuputIfNeeded() {
   }
 
   if (!global.gc) {
-    console.error(
+    logger.error(
       '❌ Reassure: measure code is running under incorrect Node.js configuration.\n' +
         'Performance test code should be run in Jest with certain Node.js flags to increase measurements stability.\n' +
         'Make sure you use the Reassure CLI and run it using "reassure" command.'
     );
-  } else if (config.verbose) {
-    console.log('✅ Reassure: measure code is running under correct node flags');
+  } else {
+    logger.verbose('✅ Reassure: measure code is running under correct node flags');
   }
 
   hasShowFlagsOutput = true;

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -1,4 +1,5 @@
 import { config, Render, Cleanup } from './config';
+import { logger } from './utils/logger';
 
 type TestingLibraryApi = {
   render: Render;
@@ -29,7 +30,7 @@ export function resolveTestingLibrary(): TestingLibraryApi {
         throw new Error(`Reassure: unable to import '@testing-library/react-native' dependency`);
       }
 
-      if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
+      logger.verbose(`Reassure: using '@testing-library/react-native' to render components`);
       return RNTL;
     }
 
@@ -38,7 +39,7 @@ export function resolveTestingLibrary(): TestingLibraryApi {
         throw new Error(`Reassure: unable to import '@testing-library/react' dependency`);
       }
 
-      if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
+      logger.log(`Reassure: using '@testing-library/react' to render components`);
       return RTL;
     }
 
@@ -47,7 +48,7 @@ export function resolveTestingLibrary(): TestingLibraryApi {
       typeof config.testingLibrary.render === 'function' &&
       typeof config.testingLibrary.cleanup === 'function'
     ) {
-      if (config.verbose) console.log(`Reassure: using custom 'render' and 'cleanup' functions to render components`);
+      logger.log(`Reassure: using custom 'render' and 'cleanup' functions to render components`);
       return config.testingLibrary;
     }
 
@@ -58,21 +59,23 @@ export function resolveTestingLibrary(): TestingLibraryApi {
 
   // Testing library auto-detection
   if (RNTL != null && RTL != null) {
-    console.warn(
-      `Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default.` +
-        `\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file.`
+    logger.warn(
+      "Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default."
+    );
+    logger.warn(
+      "You can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file."
     );
 
     return RNTL;
   }
 
   if (RNTL != null) {
-    if (config.verbose) console.log(`Reassure: using '@testing-library/react-native' to render components`);
+    logger.verbose(`Reassure: using '@testing-library/react-native' to render components`);
     return RNTL;
   }
 
   if (RTL != null) {
-    if (config.verbose) console.log(`Reassure: using '@testing-library/react' to render components`);
+    logger.verbose(`Reassure: using '@testing-library/react' to render components`);
     return RTL;
   }
 

--- a/packages/reassure-measure/src/testingLibrary.ts
+++ b/packages/reassure-measure/src/testingLibrary.ts
@@ -27,19 +27,19 @@ export function resolveTestingLibrary(): TestingLibraryApi {
   if (config.testingLibrary) {
     if (config.testingLibrary === 'react-native') {
       if (!RNTL) {
-        throw new Error(`Reassure: unable to import '@testing-library/react-native' dependency`);
+        throw new Error(`Unable to import '@testing-library/react-native' dependency`);
       }
 
-      logger.verbose(`Reassure: using '@testing-library/react-native' to render components`);
+      logger.verbose(`Using '@testing-library/react-native' to render components`);
       return RNTL;
     }
 
     if (config.testingLibrary === 'react') {
       if (!RTL) {
-        throw new Error(`Reassure: unable to import '@testing-library/react' dependency`);
+        throw new Error(`Unable to import '@testing-library/react' dependency`);
       }
 
-      logger.log(`Reassure: using '@testing-library/react' to render components`);
+      logger.log(`Using '@testing-library/react' to render components`);
       return RTL;
     }
 
@@ -48,39 +48,36 @@ export function resolveTestingLibrary(): TestingLibraryApi {
       typeof config.testingLibrary.render === 'function' &&
       typeof config.testingLibrary.cleanup === 'function'
     ) {
-      logger.log(`Reassure: using custom 'render' and 'cleanup' functions to render components`);
+      logger.log(`Using custom 'render' and 'cleanup' functions to render components`);
       return config.testingLibrary;
     }
 
     throw new Error(
-      `Reassure: unsupported 'testingLibrary' value. Please set 'testingLibrary' to one of following values: 'react-native', 'react' or { render, cleanup }.`
+      `Unsupported 'testingLibrary' value. Please set 'testingLibrary' to one of following values: 'react-native', 'react' or { render, cleanup }.`
     );
   }
 
   // Testing library auto-detection
   if (RNTL != null && RTL != null) {
     logger.warn(
-      "Reassure: both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default."
-    );
-    logger.warn(
-      "You can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file."
+      "Both '@testing-library/react-native' and '@testing-library/react' are installed. Using '@testing-library/react-native' by default.\n\nYou can resolve this warning by explicitly calling 'configure({ testingLibrary: 'react-native' })' or 'configure({ testingLibrary: 'react' })' in your test setup file."
     );
 
     return RNTL;
   }
 
   if (RNTL != null) {
-    logger.verbose(`Reassure: using '@testing-library/react-native' to render components`);
+    logger.verbose(`Using '@testing-library/react-native' to render components`);
     return RNTL;
   }
 
   if (RTL != null) {
-    logger.verbose(`Reassure: using '@testing-library/react' to render components`);
+    logger.verbose(`Using '@testing-library/react' to render components`);
     return RTL;
   }
 
   throw new Error(
-    `Reassure: unable to import neither '@testing-library/react-native' nor '@testing-library/react'.` +
+    `Unable to import neither '@testing-library/react-native' nor '@testing-library/react'.` +
       `\nAdd either of these testing libraries to your 'package.json'`
   );
 }

--- a/packages/reassure-measure/src/utils/logger.ts
+++ b/packages/reassure-measure/src/utils/logger.ts
@@ -1,3 +1,8 @@
-import { bindLogger } from '@callstack/reassure-logger';
+import { bindLogger, configure } from '@callstack/reassure-logger';
 
 export const logger = bindLogger('reassure-measure');
+
+configure({
+  verbose: process.env.REASSURE_VERBOSE === 'true',
+  silent: process.env.REASSURE_SILENT === 'true',
+});

--- a/packages/reassure-measure/src/utils/logger.ts
+++ b/packages/reassure-measure/src/utils/logger.ts
@@ -1,3 +1,3 @@
 import { bindLogger } from '@callstack/reassure-logger';
 
-export const logger = bindLogger('reassure-cli');
+export const logger = bindLogger('reassure-measure');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3099,6 +3099,14 @@ caniuse-lite@^1.0.30001400:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz#30f67d55a865da43e0aeec003f073ea8764d5d7c"
   integrity sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==
 
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3107,14 +3115,6 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.0:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Summary

Resolves #85

This PR is based on #52 by @Xiltyn, it used extract logger code with following changes:
* logger is promoted to monorepo package `reassure-logger` in order to by used by other packages: `cli`, `compare`, `measure`
* logger is implemented as JS module instead of class

### Test plan

All tests pass. 
