### PR TITLE
fix: jest-expo path

### DIFF
--- a/.changeset/sharp-singers-judge.md
+++ b/.changeset/sharp-singers-judge.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-cli': patch
+---
+
+fix: support running perf tests when user has `jest-expo` installed

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { CommandModule } from 'yargs';
 import { compare, formatMetadata } from '@callstack/reassure-compare';
@@ -16,6 +16,13 @@ export interface MeasureOptions extends CommonOptions {
   branch?: string;
   commitHash?: string;
   testMatch?: string;
+}
+
+export function getJestBinPath() {
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  const jestPackageJson = require('jest/package.json');
+  const jestPackagePath = dirname(require.resolve('jest/package.json'));
+  return resolve(jestPackagePath, jestPackageJson.bin.jest || jestPackageJson.bin);
 }
 
 export async function run(options: MeasureOptions) {
@@ -39,8 +46,8 @@ export async function run(options: MeasureOptions) {
   const header = { metadata };
   writeFileSync(outputFile, JSON.stringify(header) + '\n');
 
-  const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
-  const testRunnerPath = process.env.TEST_RUNNER_PATH ?? defaultPath;
+  // const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
+  const testRunnerPath = process.env.TEST_RUNNER_PATH ?? getJestBinPath();
 
   // NOTE: Consider updating the default testMatch to better reflect
   // default patterns used in Jest and allow users to also place their

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -46,7 +46,6 @@ export async function run(options: MeasureOptions) {
   const header = { metadata };
   writeFileSync(outputFile, JSON.stringify(header) + '\n');
 
-  // const defaultPath = process.platform === 'win32' ? 'node_modules/jest/bin/jest' : 'node_modules/.bin/jest';
   const testRunnerPath = process.env.TEST_RUNNER_PATH ?? getJestBinPath();
 
   // NOTE: Consider updating the default testMatch to better reflect


### PR DESCRIPTION
### Summary

This PR fixes issues with Jest Expo package by finding the real Jest binary instead of using `jest` which is replaced by Jest Expo.

### Test plan

All checks should pass.