### PR TITLE
fix: measureRender should exclude wrapper render durations

### DIFF
--- a/.changeset/ninety-pants-perform.md
+++ b/.changeset/ninety-pants-perform.md
@@ -1,0 +1,7 @@
+---
+'@callstack/reassure-measure': patch
+'reassure': patch
+'@callstack/reassure-cli': patch
+---
+
+fix: exclude wrapper component from render measurements

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ interface MeasureOptions {
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with
+- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapper component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ interface MeasureOptions {
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapper component is measured.
+- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ### Configuration

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -48,7 +48,7 @@ interface MeasureOptions {
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapper component is measured.
+- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ## Configuration

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -48,7 +48,7 @@ interface MeasureOptions {
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with
+- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapper component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ## Configuration

--- a/packages/reassure-measure/src/__tests__/measure.test.tsx
+++ b/packages/reassure-measure/src/__tests__/measure.test.tsx
@@ -27,6 +27,16 @@ test('measureRender run test given number of times', async () => {
   expect(scenario).toHaveBeenCalledTimes(21);
 });
 
+test('measureRender should log error when running under incorrect node flags', async () => {
+  resetHasShownFlagsOutput();
+  const result = await measureRender(<View />, { runs: 1 });
+
+  expect(result.runs).toBe(1);
+  expect(realConsole.error).toHaveBeenCalledWith(`❌ Measure code is running under incorrect Node.js configuration.
+Performance test code should be run in Jest with certain Node.js flags to increase measurements stability.
+Make sure you use the Reassure CLI and run it using "reassure" command.`);
+});
+
 test('processRunResults calculates correct means and stdevs', () => {
   const input = [
     { duration: 10, count: 2 },
@@ -43,16 +53,6 @@ test('processRunResults calculates correct means and stdevs', () => {
     stdevCount: 0,
     counts: [2, 2, 2],
   });
-});
-
-test('measureRender should log error when running under incorrect node flags', async () => {
-  resetHasShownFlagsOutput();
-  const result = await measureRender(<View />, { runs: 1 });
-
-  expect(result.runs).toBe(1);
-  expect(realConsole.error).toHaveBeenCalledWith(`❌ Measure code is running under incorrect Node.js configuration.
-Performance test code should be run in Jest with certain Node.js flags to increase measurements stability.
-Make sure you use the Reassure CLI and run it using "reassure" command.`);
 });
 
 test('processRunResults applies dropWorst option', () => {

--- a/packages/reassure-measure/src/__tests__/measure.test.tsx
+++ b/packages/reassure-measure/src/__tests__/measure.test.tsx
@@ -37,6 +37,22 @@ Performance test code should be run in Jest with certain Node.js flags to increa
 Make sure you use the Reassure CLI and run it using "reassure" command.`);
 });
 
+function IgnoreChildren(_: React.PropsWithChildren<{}>) {
+  return <View />;
+}
+
+test('measureRender does not meassure wrapper', async () => {
+  const wrapper = (ui: React.ReactElement) => <IgnoreChildren>{ui}</IgnoreChildren>;
+  const result = await measureRender(<View />, { wrapper });
+  expect(result.runs).toBe(10);
+  expect(result.durations).toHaveLength(10);
+  expect(result.counts).toHaveLength(10);
+  expect(result.meanDuration).toBe(0);
+  expect(result.meanCount).toBe(0);
+  expect(result.stdevDuration).toBe(0);
+  expect(result.stdevCount).toBe(0);
+});
+
 test('processRunResults calculates correct means and stdevs', () => {
   const input = [
     { duration: 10, count: 2 },

--- a/packages/reassure-measure/src/measure.tsx
+++ b/packages/reassure-measure/src/measure.tsx
@@ -34,7 +34,6 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
   const scenario = options?.scenario;
   const dropWorst = options?.dropWorst ?? config.dropWorst;
 
-  const wrappedUi = wrapper ? wrapper(ui) : ui;
   const { render, cleanup } = resolveTestingLibrary();
 
   showFlagsOuputIfNeeded();
@@ -55,11 +54,14 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
       }
     };
 
-    const screen = render(
-      <React.Profiler id="Test" onRender={handleRender}>
-        {wrappedUi}
+    const uiWithProfiler = (
+      <React.Profiler id="REASSURE_ROOT" onRender={handleRender}>
+        {ui}
       </React.Profiler>
     );
+
+    const uiToRender = wrapper ? wrapper(uiWithProfiler) : uiWithProfiler;
+    const screen = render(uiToRender);
 
     if (scenario) {
       await scenario(screen);

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -392,7 +392,7 @@ interface MeasureOptions {
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with
+- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapper component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ### Configuration

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -392,7 +392,7 @@ interface MeasureOptions {
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapper component is measured.
+- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ### Configuration


### PR DESCRIPTION
### Summary

This PR excludes wrapper component passed using `wrapper` option to `measureRender`/`measurePerformance` from being included in the render stats.


### Test plan

Added test to detect wrapper render.