### PR TITLE
(BREAKING) feat: make wrapper option compatible with RTL/RNTL

### DIFF
--- a/.changeset/stupid-suits-learn.md
+++ b/.changeset/stupid-suits-learn.md
@@ -1,0 +1,7 @@
+---
+'@callstack/reassure-measure': minor
+'reassure': minor
+'@callstack/reassure-cli': minor
+---
+
+(BREAKING) feat: `wrapper` option for `measurePerformance`/`measureRender` function now accepts a React component instead of wrapper function.

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ async function measurePerformance(ui: React.ReactElement, options?: MeasureOptio
 interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: React.ComponentType<any>;
+  wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -385,14 +385,14 @@ async function measurePerformance(ui: React.ReactElement, options?: MeasureOptio
 interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: (node: React.ReactElement) => JSX.Element;
+  wrapper?: React.ComponentType<any>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
+- **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ### Configuration

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -41,14 +41,14 @@ test('Test with scenario', async () => {
 interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: (node: React.ReactElement) => JSX.Element;
+  wrapper?: React.ComponentType<any>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
+- **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ## Configuration

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -41,7 +41,7 @@ test('Test with scenario', async () => {
 interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: React.ComponentType<any>;
+  wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```

--- a/packages/reassure-measure/src/measure.tsx
+++ b/packages/reassure-measure/src/measure.tsx
@@ -14,7 +14,7 @@ logger.configure({
 export interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: (node: React.ReactElement) => JSX.Element;
+  wrapper?: React.ComponentType<any>;
   scenario?: (screen: any) => Promise<any>;
 }
 
@@ -30,7 +30,6 @@ export async function measurePerformance(
 
 export async function measureRender(ui: React.ReactElement, options?: MeasureOptions): Promise<MeasureRenderResult> {
   const runs = options?.runs ?? config.runs;
-  const wrapper = options?.wrapper;
   const scenario = options?.scenario;
   const dropWorst = options?.dropWorst ?? config.dropWorst;
 
@@ -54,13 +53,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
       }
     };
 
-    const uiWithProfiler = (
-      <React.Profiler id="REASSURE_ROOT" onRender={handleRender}>
-        {ui}
-      </React.Profiler>
-    );
-
-    const uiToRender = wrapper ? wrapper(uiWithProfiler) : uiWithProfiler;
+    const uiToRender = buildUiToRender(ui, handleRender, options?.wrapper);
     const screen = render(uiToRender);
 
     if (scenario) {
@@ -83,6 +76,20 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
   }
 
   return processRunResults(runResults, dropWorst);
+}
+
+export function buildUiToRender(
+  ui: React.ReactElement,
+  onRender: React.ProfilerOnRenderCallback,
+  Wrapper?: React.ComponentType<any>
+) {
+  const uiWithProfiler = (
+    <React.Profiler id="REASSURE_ROOT" onRender={onRender}>
+      {ui}
+    </React.Profiler>
+  );
+
+  return Wrapper ? <Wrapper>{uiWithProfiler}</Wrapper> : uiWithProfiler;
 }
 
 interface RunResult {

--- a/packages/reassure-measure/src/measure.tsx
+++ b/packages/reassure-measure/src/measure.tsx
@@ -14,7 +14,7 @@ logger.configure({
 export interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: React.ComponentType<any>;
+  wrapper?: React.ComponentType<{ children: React.ReactElement }>;
   scenario?: (screen: any) => Promise<any>;
 }
 
@@ -81,7 +81,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
 export function buildUiToRender(
   ui: React.ReactElement,
   onRender: React.ProfilerOnRenderCallback,
-  Wrapper?: React.ComponentType<any>
+  Wrapper?: React.ComponentType<{ children: React.ReactElement }>
 ) {
   const uiWithProfiler = (
     <React.Profiler id="REASSURE_ROOT" onRender={onRender}>

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -385,7 +385,7 @@ async function measurePerformance(ui: React.ReactElement, options?: MeasureOptio
 interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: React.ComponentType<any>;
+  wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -385,14 +385,14 @@ async function measurePerformance(ui: React.ReactElement, options?: MeasureOptio
 interface MeasureOptions {
   runs?: number;
   dropWorst?: number;
-  wrapper?: (node: React.ReactElement) => JSX.Element;
+  wrapper?: React.ComponentType<any>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
 - **`dropWorst`**: number of worst (highest) runs dropped from a test series
-- **`wrapper`**: custom JSX wrapper, such as a `<Provider />` component, which the ui needs to be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
+- **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
 ### Configuration


### PR DESCRIPTION
### Summary

Currently the `wrapper` option accepts a wrapping function: 
```
(node: React.ReactElement) => JSX.Element;
```

However, both RNTL and RTL accept a wrapper component type:
```
wrapper?: React.ComponentType<any>;
```

Each approach can be relatively easy transformed to the other one, but having slightly different wrapper types make adapting tests from RNTL, RTL slightly more cumbersome.

This is a breaking change, but since we are pre 1.0 version it should result in minor version change (probably 0.9.0).

### Test plan

Added test that checks if the wrapper is placed in the proper place in the element tree.