### PR TITLE
(BREAKING) refactor: rename dropWorst to warmupRuns

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,14 +384,14 @@ async function measurePerformance(ui: React.ReactElement, options?: MeasureOptio
 ```ts
 interface MeasureOptions {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
-- **`dropWorst`**: number of worst (highest) runs dropped from a test series
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs (default 1).
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
@@ -405,7 +405,7 @@ of the `configure` function.
 ```ts
 type Config = {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   outputFile?: string;
   verbose?: boolean;
   testingLibrary?:
@@ -418,7 +418,7 @@ type Config = {
 ```ts
 const defaultConfig: Config = {
   runs: 10,
-  dropWorst: 1,
+  warmupRuns: 1,
   outputFile: '.reassure/current.perf',
   verbose: false,
   testingLibrary: undefined, // Will try auto-detect first RNTL, then RTL
@@ -426,7 +426,7 @@ const defaultConfig: Config = {
 ```
 
 **`runs`**: number of repeated runs in a series per test (allows for higher accuracy by aggregating more data). Should be handled with care.
-**`dropWorst`**: number of worst dropped results from the series per test (used to remove test run outliers)
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
 **`outputFile`**: name of the file the records will be saved to
 **`verbose`**: make Reassure log more, e.g. for debugging purposes
 **`testingLibrary`**: where to look for `render` and `cleanup` functions, supported values `'react-native'`, `'react'` or object providing custom `render` and `cleanup` functions

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -40,14 +40,14 @@ test('Test with scenario', async () => {
 ```ts
 interface MeasureOptions {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
-- **`dropWorst`**: number of worst (highest) runs dropped from a test series
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
@@ -61,7 +61,7 @@ of the `configure` function.
 ```ts
 type Config = {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   outputFile?: string;
   verbose?: boolean;
   testingLibrary?:
@@ -74,7 +74,7 @@ type Config = {
 ```ts
 const defaultConfig: Config = {
   runs: 10,
-  dropWorst: 1,
+  warmupRuns: 1,
   outputFile: '.reassure/current.perf',
   verbose: false,
   testingLibrary: undefined, // Will try auto-detect first RNTL, then RTL
@@ -82,7 +82,7 @@ const defaultConfig: Config = {
 ```
 
 **`runs`**: number of repeated runs in a series per test (allows for higher accuracy by aggregating more data). Should be handled with care.
-**`dropWorst`**: number of worst dropped results from the series per test (used to remove test run outliers)
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
 **`outputFile`**: name of the file the records will be saved to
 **`verbose`**: make Reassure log more, e.g. for debugging purposes
 **`testingLibrary`**: where to look for `render` and `cleanup` functions, supported values `'react-native'`, `'react'` or object providing custom `render` and `cleanup` functions

--- a/packages/reassure-measure/src/__tests__/measure.test.tsx
+++ b/packages/reassure-measure/src/__tests__/measure.test.tsx
@@ -108,12 +108,12 @@ test('processRunResults calculates correct means and stdevs', () => {
   });
 });
 
-test('processRunResults applies dropWorst option', () => {
+test('processRunResults applies warmupRuns option', () => {
   const input = [
+    { duration: 23, count: 1 },
     { duration: 20, count: 5 },
     { duration: 24, count: 5 },
     { duration: 22, count: 5 },
-    { duration: 1000, count: 1 },
   ];
 
   expect(processRunResults(input, 1)).toEqual({

--- a/packages/reassure-measure/src/config.ts
+++ b/packages/reassure-measure/src/config.ts
@@ -5,14 +5,14 @@ export type Cleanup = () => void;
 
 type Config = {
   runs: number;
-  dropWorst: number;
+  warmupRuns: number;
   outputFile: string;
   testingLibrary?: TestingLibrary;
 };
 
 const defaultConfig: Config = {
   runs: 10,
-  dropWorst: 1,
+  warmupRuns: 1,
   outputFile: process.env.REASSURE_OUTPUT_FILE ?? '.reassure/current.perf',
   testingLibrary: undefined,
 };

--- a/packages/reassure-measure/src/measure.tsx
+++ b/packages/reassure-measure/src/measure.tsx
@@ -13,7 +13,7 @@ logger.configure({
 
 export interface MeasureOptions {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   wrapper?: React.ComponentType<{ children: React.ReactElement }>;
   scenario?: (screen: any) => Promise<any>;
 }
@@ -31,7 +31,7 @@ export async function measurePerformance(
 export async function measureRender(ui: React.ReactElement, options?: MeasureOptions): Promise<MeasureRenderResult> {
   const runs = options?.runs ?? config.runs;
   const scenario = options?.scenario;
-  const dropWorst = options?.dropWorst ?? config.dropWorst;
+  const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
 
   const { render, cleanup } = resolveTestingLibrary();
 
@@ -39,7 +39,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
 
   const runResults: RunResult[] = [];
   let hasTooLateRender = false;
-  for (let i = 0; i < runs + dropWorst; i += 1) {
+  for (let i = 0; i < runs + warmupRuns; i += 1) {
     let duration = 0;
     let count = 0;
     let isFinished = false;
@@ -75,7 +75,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
     );
   }
 
-  return processRunResults(runResults, dropWorst);
+  return processRunResults(runResults, warmupRuns);
 }
 
 export function buildUiToRender(
@@ -97,9 +97,9 @@ interface RunResult {
   count: number;
 }
 
-export function processRunResults(results: RunResult[], dropWorst: number) {
+export function processRunResults(results: RunResult[], warmupRuns: number) {
+  results = results.slice(warmupRuns);
   results.sort((first, second) => second.duration - first.duration); // duration DESC
-  results = results.slice(dropWorst);
 
   const durations = results.map((result) => result.duration);
   const meanDuration = math.mean(durations) as number;

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -384,14 +384,14 @@ async function measurePerformance(ui: React.ReactElement, options?: MeasureOptio
 ```ts
 interface MeasureOptions {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
-- **`dropWorst`**: number of worst (highest) runs dropped from a test series
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 
@@ -405,7 +405,7 @@ of the `configure` function.
 ```ts
 type Config = {
   runs?: number;
-  dropWorst?: number;
+  warmupRuns?: number;
   outputFile?: string;
   verbose?: boolean;
   testingLibrary?:
@@ -418,7 +418,7 @@ type Config = {
 ```ts
 const defaultConfig: Config = {
   runs: 10,
-  dropWorst: 1,
+  warmupRuns: 1,
   outputFile: '.reassure/current.perf',
   verbose: false,
   testingLibrary: undefined, // Will try auto-detect first RNTL, then RTL
@@ -426,7 +426,7 @@ const defaultConfig: Config = {
 ```
 
 **`runs`**: number of repeated runs in a series per test (allows for higher accuracy by aggregating more data). Should be handled with care.
-**`dropWorst`**: number of worst dropped results from the series per test (used to remove test run outliers)
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
 **`outputFile`**: name of the file the records will be saved to
 **`verbose`**: make Reassure log more, e.g. for debugging purposes
 **`testingLibrary`**: where to look for `render` and `cleanup` functions, supported values `'react-native'`, `'react'` or object providing custom `render` and `cleanup` functions


### PR DESCRIPTION
### Summary

Based on the developer feedback the `dropWorst` parameter was not well named nor understood. This PR changes the name to `warmupRuns` and slightly tweak the logic to discard first runs and not the highest runes (these were usually the same runs).

### Test plan

Relevant tests have been tweaked.