### PR TITLE
fix: removed "node:" prefix from logger readline

### DIFF
--- a/.changeset/purple-pumas-love.md
+++ b/.changeset/purple-pumas-love.md
@@ -2,4 +2,4 @@
 '@callstack/reassure-logger': patch
 ---
 
-Removed "node:" prefix from readline import
+Removed "node:" prefix from "readline" import.

--- a/.changeset/purple-pumas-love.md
+++ b/.changeset/purple-pumas-love.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-logger': patch
+---
+
+Removed node: prefix from readline import

--- a/.changeset/purple-pumas-love.md
+++ b/.changeset/purple-pumas-love.md
@@ -2,4 +2,4 @@
 '@callstack/reassure-logger': patch
 ---
 
-Removed node: prefix from readline import
+Removed "node:" prefix from readline import

--- a/packages/reassure-logger/src/logger.ts
+++ b/packages/reassure-logger/src/logger.ts
@@ -1,4 +1,4 @@
-import readline from 'node:readline';
+import readline from 'readline';
 import chalk from 'chalk';
 import { colors } from './colors';
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Running reassure got the error on `node:readline`

Removing the `node:` prefix worked

<img width="941" alt="Screen Shot 2023-05-10 at 10 12 21" src="https://github.com/callstack/reassure/assets/1676818/a095ac69-7fdc-4a6a-b22e-1bc24360e9b3">


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
