### PR TITLE
fix: Correct minor typos in log output

### DIFF
--- a/packages/reassure-compare/src/compare.ts
+++ b/packages/reassure-compare/src/compare.ts
@@ -16,7 +16,7 @@ import { errors, warnings, logError, logWarning } from './utils/logs';
 import { parseHeader, parsePerformanceEntries } from './utils/validate';
 
 /**
- * Probability threshold for considering given difference signficiant.
+ * Probability threshold for considering given difference significant.
  */
 const PROBABILITY_CONSIDERED_SIGNIFICANT = 0.02;
 
@@ -176,7 +176,7 @@ function compareResults(current: PerformanceResults, baseline: PerformanceResult
 }
 
 /**
- * Establish statisticial signficance of render duration difference build compare entry.
+ * Establish statisticial significance of render duration difference build compare entry.
  */
 function buildCompareEntry(name: string, current: PerformanceEntry, baseline: PerformanceEntry): CompareEntry {
   const durationDiff = current.meanDuration - baseline.meanDuration;

--- a/packages/reassure-compare/src/output/console.ts
+++ b/packages/reassure-compare/src/output/console.ts
@@ -16,7 +16,7 @@ export function printToConsole(data: CompareResult) {
   printMetadata('Current', data.metadata.current);
   printMetadata('Baseline', data.metadata.baseline);
 
-  logger.log('\n➡️  Signficant changes to render duration');
+  logger.log('\n➡️  Significant changes to render duration');
   data.significant.forEach(printRegularLine);
 
   logger.log('\n➡️  Meaningless changes to render duration');


### PR DESCRIPTION
### Summary

Found a minor typo while setting up Reassurance.

### Test plan

- Run a test
- Read the logs

Before:
<img width="705" alt="image" src="https://github.com/callstack/reassure/assets/1444472/db020170-f46a-4bc1-bf7a-64d12655edde">

