### PR TITLE
hotfix: make measureFunction a public API

### DIFF
--- a/.changeset/funny-pandas-repeat.md
+++ b/.changeset/funny-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+'reassure': patch
+---
+
+hotfix: make measureFunction a publicly available API

--- a/packages/reassure/src/index.ts
+++ b/packages/reassure/src/index.ts
@@ -1,3 +1,3 @@
-export { measurePerformance, configure, resetToDefault } from '@callstack/reassure-measure';
+export { measurePerformance, measureFunction, configure, resetToDefault } from '@callstack/reassure-measure';
 
 export { dangerReassure } from '@callstack/reassure-danger';


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR fixes lack of the `measureFunction` function in the public API.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Put `import {measureFunction} from 'reassure';` in your test file.