### PR TITLE
Recharts vitest

### DIFF
--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -175,14 +175,3 @@ export function getBinPath(runner: string) {
     return null;
   }
 }
-
-export function getJestBinPath() {
-  try {
-    // eslint-disable-next-line import/no-extraneous-dependencies
-    const jestPackageJson = require('jest/package.json');
-    const jestPackagePath = dirname(require.resolve('jest/package.json'));
-    return resolve(jestPackagePath, jestPackageJson.bin.jest || jestPackageJson.bin);
-  } catch (error) {
-    return null;
-  }
-}

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -170,7 +170,7 @@ export function getBinPath(runner: string) {
     // eslint-disable-next-line import/no-extraneous-dependencies
     const runnerPackageJson = require(`${runner}/package.json`);
     const runnerPackagePath = dirname(require.resolve(`${runner}/package.json`));
-    return resolve(runnerPackagePath, runnerPackageJson.bin.jest || runnerPackageJson.bin);
+    return resolve(runnerPackagePath, runnerPackageJson.bin['runner'] || runnerPackageJson.bin);
   } catch (error) {
     return null;
   }

--- a/packages/reassure-cli/src/commands/measure.ts
+++ b/packages/reassure-cli/src/commands/measure.ts
@@ -16,6 +16,7 @@ export interface MeasureOptions extends CommonOptions {
   branch?: string;
   commitHash?: string;
   testMatch?: string;
+  runner?: string;
 }
 
 export async function run(options: MeasureOptions) {
@@ -145,6 +146,11 @@ export const command: CommandModule<{}, MeasureOptions> = {
         type: 'string',
         default: undefined,
         describe: 'Run performance tests for a specific test file',
+      })
+      .option('runner', {
+        type: 'string',
+        default: 'jest',
+        describe: 'Specify which test runner to use. Valid values are: jest (default) and vitest.',
       });
   },
   handler: (args) => run(args),


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Allows for users to pass in `--runner` flag to use either `jest` or `vitest` for the test runner. Defaults to `jest if no value is provided.

[Issue link](https://github.com/callstack/reassure/issues/421)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
