### PR TITLE
feat: quick 3 run scheme

### DIFF
--- a/packages/reassure-measure/src/__tests__/measure-function.test.tsx
+++ b/packages/reassure-measure/src/__tests__/measure-function.test.tsx
@@ -41,3 +41,15 @@ test('measureFunctionInternal applies dropsWorst option', () => {
   expect(results.meanCount).toBe(1);
   expect(results.stdevCount).toBe(0);
 });
+
+test('measureFunctionInternal supports "runs: quick-3" option', () => {
+  const fn = jest.fn(() => fib(5));
+  const results = measureFunctionInternal(fn, { runs: 'quick-3', warmupRuns: 1 });
+
+  expect(fn).toHaveBeenCalledTimes(4);
+  expect(results.runs).toBe(6);
+  expect(results.durations).toHaveLength(6);
+  expect(results.counts).toHaveLength(6);
+  expect(results.meanCount).toBe(1);
+  expect(results.stdevCount).toBe(0);
+});

--- a/packages/reassure-measure/src/__tests__/measure-helpers.test.ts
+++ b/packages/reassure-measure/src/__tests__/measure-helpers.test.ts
@@ -7,7 +7,7 @@ test('processRunResults calculates correct means and stdevs', () => {
     { duration: 14, count: 2 },
   ];
 
-  expect(processRunResults(input, 0)).toEqual({
+  expect(processRunResults(input, 3, 0)).toEqual({
     runs: 3,
     meanDuration: 12,
     stdevDuration: 2,
@@ -20,13 +20,13 @@ test('processRunResults calculates correct means and stdevs', () => {
 
 test('processRunResults applies warmupRuns option', () => {
   const input = [
-    { duration: 23, count: 1 },
+    { duration: 23, count: 1 }, // warmup run
     { duration: 20, count: 5 },
     { duration: 24, count: 5 },
     { duration: 22, count: 5 },
   ];
 
-  expect(processRunResults(input, 1)).toEqual({
+  expect(processRunResults(input, 4, 1)).toEqual({
     runs: 3,
     meanDuration: 22,
     stdevDuration: 2,
@@ -34,5 +34,24 @@ test('processRunResults applies warmupRuns option', () => {
     meanCount: 5,
     stdevCount: 0,
     counts: [5, 5, 5],
+  });
+});
+
+test('processRunResults supports "runs: quick-3" option', () => {
+  const input = [
+    { duration: 100, count: 1 }, // warmup run
+    { duration: 1, count: 5 },
+    { duration: 6, count: 5 },
+    { duration: 29, count: 5 },
+  ];
+
+  expect(processRunResults(input, 'quick-3', 1)).toEqual({
+    runs: 6,
+    meanDuration: 9,
+    stdevDuration: 10,
+    durations: [29, 6, 6, 6, 6, 1],
+    meanCount: 5,
+    stdevCount: 0,
+    counts: [5, 5, 5, 5, 5, 5],
   });
 });

--- a/packages/reassure-measure/src/__tests__/measure-render.test.tsx
+++ b/packages/reassure-measure/src/__tests__/measure-render.test.tsx
@@ -89,3 +89,27 @@ test('buildUiToRender does not wrap when no wrapper is passed', () => {
     </UNDEFINED>
   `);
 });
+
+test('measureRender applies dropsWorst option', async () => {
+  const scenario = jest.fn(() => Promise.resolve(null));
+  const results = await measureRender(<View />, { runs: 10, warmupRuns: 1, scenario });
+
+  expect(scenario).toHaveBeenCalledTimes(11);
+  expect(results.runs).toBe(10);
+  expect(results.durations).toHaveLength(10);
+  expect(results.counts).toHaveLength(10);
+  expect(results.meanCount).toBe(1);
+  expect(results.stdevCount).toBe(0);
+});
+
+test('measureRender supports "runs: quick-3" option', async () => {
+  const scenario = jest.fn(() => Promise.resolve(null));
+  const results = await measureRender(<View />, { runs: 'quick-3', warmupRuns: 1, scenario });
+
+  expect(scenario).toHaveBeenCalledTimes(4);
+  expect(results.runs).toBe(6);
+  expect(results.durations).toHaveLength(6);
+  expect(results.counts).toHaveLength(6);
+  expect(results.meanCount).toBe(1);
+  expect(results.stdevCount).toBe(0);
+});

--- a/packages/reassure-measure/src/config.ts
+++ b/packages/reassure-measure/src/config.ts
@@ -4,7 +4,7 @@ export type Render = (component: React.ReactElement<any>) => any;
 export type Cleanup = () => void;
 
 type Config = {
-  runs: number;
+  runs: number | 'quick-3';
   warmupRuns: number;
   outputFile: string;
   testingLibrary?: TestingLibrary;

--- a/packages/reassure-measure/src/measure-function.tsx
+++ b/packages/reassure-measure/src/measure-function.tsx
@@ -5,7 +5,7 @@ import { type RunResult, processRunResults } from './measure-helpers';
 import { showFlagsOuputIfNeeded, writeTestStats } from './output';
 
 interface MeasureFunctionOptions {
-  runs?: number;
+  runs?: number | 'quick-3';
   warmupRuns?: number;
 }
 
@@ -18,12 +18,13 @@ export async function measureFunction(fn: () => void, options?: MeasureFunctionO
 
 export function measureFunctionInternal(fn: () => void, options?: MeasureFunctionOptions): MeasureResults {
   const runs = options?.runs ?? config.runs;
+  const runCount = runs === 'quick-3' ? 3 : runs;
   const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
 
   showFlagsOuputIfNeeded();
 
   const runResults: RunResult[] = [];
-  for (let i = 0; i < runs + warmupRuns; i += 1) {
+  for (let i = 0; i < runCount + warmupRuns; i += 1) {
     const timeStart = getCurrentTime();
     fn();
     const timeEnd = getCurrentTime();
@@ -32,7 +33,7 @@ export function measureFunctionInternal(fn: () => void, options?: MeasureFunctio
     runResults.push({ duration, count: 1 });
   }
 
-  return processRunResults(runResults, warmupRuns);
+  return processRunResults(runResults, runs, warmupRuns);
 }
 
 function getCurrentTime() {

--- a/packages/reassure-measure/src/measure-helpers.tsx
+++ b/packages/reassure-measure/src/measure-helpers.tsx
@@ -6,9 +6,14 @@ export interface RunResult {
   count: number;
 }
 
-export function processRunResults(results: RunResult[], warmupRuns: number): MeasureResults {
+export function processRunResults(results: RunResult[], runs: number | 'quick-3', warmupRuns: number): MeasureResults {
   results = results.slice(warmupRuns);
+
   results.sort((first, second) => second.duration - first.duration); // duration DESC
+
+  if (runs === 'quick-3') {
+    results = [results[0], results[1], results[1], results[1], results[1], results[2]];
+  }
 
   const durations = results.map((result) => result.duration);
   const meanDuration = math.mean(durations) as number;

--- a/packages/reassure-measure/src/measure-render.tsx
+++ b/packages/reassure-measure/src/measure-render.tsx
@@ -12,7 +12,7 @@ logger.configure({
 });
 
 export interface MeasureOptions {
-  runs?: number;
+  runs?: number | 'quick-3';
   warmupRuns?: number;
   wrapper?: React.ComponentType<{ children: React.ReactElement }>;
   scenario?: (screen: any) => Promise<any>;
@@ -27,6 +27,8 @@ export async function measurePerformance(ui: React.ReactElement, options?: Measu
 
 export async function measureRender(ui: React.ReactElement, options?: MeasureOptions): Promise<MeasureResults> {
   const runs = options?.runs ?? config.runs;
+  const runCount = runs === 'quick-3' ? 3 : runs;
+
   const scenario = options?.scenario;
   const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
 
@@ -36,7 +38,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
 
   const runResults: RunResult[] = [];
   let hasTooLateRender = false;
-  for (let i = 0; i < runs + warmupRuns; i += 1) {
+  for (let i = 0; i < runCount + warmupRuns; i += 1) {
     let duration = 0;
     let count = 0;
     let isFinished = false;
@@ -72,7 +74,7 @@ export async function measureRender(ui: React.ReactElement, options?: MeasureOpt
     );
   }
 
-  return processRunResults(runResults, warmupRuns);
+  return processRunResults(runResults, runs, warmupRuns);
 }
 
 export function buildUiToRender(

--- a/test-apps/native/src/OtherTest.perf-test.tsx
+++ b/test-apps/native/src/OtherTest.perf-test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { fireEvent, RenderAPI, screen } from '@testing-library/react-native';
-import { measurePerformance } from 'reassure';
+import { measurePerformance, configure } from 'reassure';
+
+configure({ runs: 'quick-3' });
 
 import { SlowList } from './SlowList';
 

--- a/test-apps/native/src/SlowList.perf-test.tsx
+++ b/test-apps/native/src/SlowList.perf-test.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { fireEvent, screen } from '@testing-library/react-native';
-import { measurePerformance } from 'reassure';
+import { measurePerformance, configure } from 'reassure';
 import { SlowList } from './SlowList';
+
+configure({ runs: 'quick-3' });
 
 const AsyncComponent = () => {
   const [count, setCount] = React.useState(0);

--- a/test-apps/native/src/fib.perf-test.tsx
+++ b/test-apps/native/src/fib.perf-test.tsx
@@ -1,4 +1,6 @@
-import { measureFunction } from '@callstack/reassure-measure';
+import { configure, measureFunction } from '@callstack/reassure-measure';
+
+configure({ runs: 'quick-3' });
 
 function fib(n: number): number {
   if (n <= 1) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This experimental scheme of test runs will run the test 3 times (plus any additional warmup runs to be discarded). This will result in three test results: min, mid & max. We then modify the run table to contain the following content: [min, mid, mid, mid, mid, max], effectively quadrupling the middle measurement.

The idea is based on [PERT distribution](https://en.wikipedia.org/wiki/PERT_distribution). Since I am not a statistician, I propose this PR as an engineering exercise when we would verify its usefulness against some stability test. The main benefit being in reducing the default 11 runs (10 real + 1 warmup) to just 4 runs (3 runs + 1 warmpu).

### Test plan

This method should undergo stability testing to compare how well or badly it fares against the default `run: 10` scheme.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
