### PR TITLE
chore: enable WASM support

### DIFF
--- a/.changeset/nasty-cars-attack.md
+++ b/.changeset/nasty-cars-attack.md
@@ -1,0 +1,6 @@
+---
+'@callstack/reassure-cli': patch
+'reassure': patch
+---
+
+feat: Experimental options to enable WebAssembly (--enable-wasm)

--- a/docusaurus/docs/troubleshooting.md
+++ b/docusaurus/docs/troubleshooting.md
@@ -1,0 +1,18 @@
+---
+title: Troubleshooting
+sidebar_position: 5
+---
+
+### Handling `ReferenceError: WebAssembly is not defined`
+
+Reassure, by default, uses Node.js's `--jitless` flag to disable its optimizing compiler to increase test stability. This flag prevents WebAssembly (WASM) from running because of internal Node.js architecture. In some cases, you might still allow your tests to include code depending on WASM, e.g., the `fetch` method is implemented using WASM.
+
+In such cases, pass the `--enable-wasm` flag to Reassure CLI:
+
+```sh
+$ reassure --enable-wasm
+```
+
+This option will replace the Node.js `--jitless` flag with alternative flags to achieve a similar stabilizing effect.
+
+Note that this option is experimental and may negatively affect the stability of your tests.

--- a/packages/reassure-cli/src/commands/check-stability.ts
+++ b/packages/reassure-cli/src/commands/check-stability.ts
@@ -14,7 +14,12 @@ export const command: CommandModule<{}, CommonOptions> = {
   command: 'check-stability',
   describe: 'Checks how stable is the current machine by running measurements twice for the same code',
   builder: (yargs) => {
-    return applyCommonOptions(yargs);
+    return applyCommonOptions(yargs).option('enable-wasm', {
+      type: 'boolean',
+      default: false,
+      describe:
+        '(experimental) Enables WebAssembly support in tests by modifying Node flags. This may affect test stability.',
+    });
   },
   handler: (args) => run(args),
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR adds support for Reassure `--enable-wasm` option that would replace `--jitless` flag for `--no-opt --no-sparkplug` flags intended to disable Turbo Fan optimizing compiler and Sparkplug non-optimizing compiler in order to maintain execution time stability provided by JIT-less mode.

Resolves #426 
Resolves #421

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
