### PR TITLE
fix: iso date milliseconds regex

### DIFF
--- a/packages/compare/package.json
+++ b/packages/compare/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@callstack/reassure-logger": "1.0.0-rc.3",
     "markdown-table": "^2.0.0",
+    "ts-regex-builder": "^1.7.1",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/packages/compare/src/utils/format.ts
+++ b/packages/compare/src/utils/format.ts
@@ -1,3 +1,4 @@
+import { buildRegExp, digit, repeat } from 'ts-regex-builder';
 import type { CompareEntry, PerformanceMetadata } from '../types';
 
 /**
@@ -106,9 +107,11 @@ function formatCommitMetadata(metadata?: PerformanceMetadata) {
   return metadata?.branch || metadata?.commitHash || '(unknown)';
 }
 
+const isoDateMilliseconds = buildRegExp(['.', repeat(digit, 3), 'Z']);
+
 function formatDateTime(dateString: string) {
-  // Remove 'T' and miliseconds part
-  return dateString.replace('T', ' ').replace(/.\d\d\dZ/, 'Z');
+  // Remove 'T' and milliseconds part
+  return dateString.replace('T', ' ').replace(isoDateMilliseconds, 'Z');
 }
 
 export function formatMetadata(metadata?: PerformanceMetadata) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2308,6 +2308,7 @@ __metadata:
     markdown-table: "npm:^2.0.0"
     prettier: "npm:^2.8.8"
     react-native-builder-bob: "npm:^0.20.3"
+    ts-regex-builder: "npm:^1.7.1"
     typescript: "npm:^5.2.2"
     zod: "npm:^3.20.2"
   languageName: unknown
@@ -12326,6 +12327,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 10c0/8ddb493e7ae581d3f57a2e469142feb60b420d4ad8366ab969fe8e36531f8f301f370676b47e8d97f28b5f5fd10d6f2d55f656943a8546ef95e35ce5cf117754
+  languageName: node
+  linkType: hard
+
+"ts-regex-builder@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "ts-regex-builder@npm:1.7.1"
+  checksum: 10c0/c128e470d0f508064fa278b322edd1cc520ad869caf578cfb7ecde72a7175d77a1d43e1559a95f1d49ee2b0b3efb9521731352ab380991d204750b5e9ca05a4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fix unescaped regex pattern (`.`)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
