### PR TITLE
chore: export types

### DIFF
--- a/docusaurus/docs/migration-v1.md
+++ b/docusaurus/docs/migration-v1.md
@@ -46,6 +46,23 @@ This means that:
 
 ## Non-breaking changes
 
+### Exporting of `Measure*` and `Compare*` types
+
+Reassure now exports following TypeScript types from root `reassure` package:
+
+- `MeasureResults` - return type of `measureRenders` and `measureFunction`
+- `MeasureRendersOptions` - options passed to `measureRenders`
+- `MeasureFunctionOptions` - options passed to `measureFunction`
+- `MeasureType` - type of measurement: `render` or `function`
+- `MeasureHeader` - header from performance file (`baseline.perf`, `current.perf`)
+- `MeasureMetadata` - metadata from performance file
+- `MeasureEntry` - single entry from performance file
+- `CompareResult` - format of `output.json` file
+- `CompareMetadata` - metadata from `output.json` file
+- `CompareEntry` - single comparison result from `output.json` file
+- `AddedEntry` - similar to `CompareEntry` but for cases when there is only `current` measurement
+- `RemovedEntry` - similar to `CompareEntry` but for cases when there is only `baseline` measurement
+
 ### Removal of `--enable-wasm` flag
 
 Reassure now runs tests with WebAssembly enable by default (see [testing environment](#testing-environment)).

--- a/packages/cli/src/commands/measure.ts
+++ b/packages/cli/src/commands/measure.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { CommandModule } from 'yargs';
 import { compare, formatMetadata } from '@callstack/reassure-compare';
-import type { PerformanceMetadata } from '@callstack/reassure-compare';
+import type { MeasureMetadata } from '@callstack/reassure-compare';
 import * as logger from '@callstack/reassure-logger';
 import { RESULTS_DIRECTORY, RESULTS_FILE, BASELINE_FILE } from '../constants';
 import { applyCommonOptions, CommonOptions } from '../options';
@@ -25,7 +25,7 @@ export async function run(options: MeasureOptions) {
 
   const measurementType = options.baseline ? 'Baseline' : 'Current';
 
-  const metadata: PerformanceMetadata = {
+  const metadata: MeasureMetadata = {
     creationDate: new Date().toISOString(),
     branch: options?.branch ?? (await getGitBranch()),
     commitHash: options?.commitHash ?? (await getGitCommitHash()),

--- a/packages/compare/src/compare.ts
+++ b/packages/compare/src/compare.ts
@@ -5,15 +5,15 @@ import type {
   RemovedEntry,
   CompareEntry,
   CompareResult,
-  PerformanceResults,
-  PerformanceEntry,
-  PerformanceHeader,
+  MeasureResults,
+  MeasureEntry,
+  MeasureHeader,
 } from './types';
 import { printToConsole } from './output/console';
 import { writeToJson } from './output/json';
 import { writeToMarkdown } from './output/markdown';
 import { errors, warnings, logError, logWarning } from './utils/logs';
-import { parseHeader, parsePerformanceEntries } from './utils/validate';
+import { parseHeader, parseMeasureEntries } from './utils/validate';
 
 /**
  * Probability threshold for considering given difference significant.
@@ -57,7 +57,7 @@ export async function compare({
     logError(`Current results files "${currentFile}" does not exists. Check your setup.`);
     process.exit(1);
   }
-  let currentResults: PerformanceResults;
+  let currentResults: MeasureResults;
   try {
     currentResults = loadFile(currentFile);
   } catch (error) {
@@ -72,7 +72,7 @@ export async function compare({
     );
   }
 
-  let baselineResults: PerformanceResults | null = null;
+  let baselineResults: MeasureResults | null = null;
   if (hasBaselineFile) {
     try {
       baselineResults = loadFile(baselineFile);
@@ -98,7 +98,7 @@ export async function compare({
 /**
  * Load performance file and parse it to `PerformanceRecord` object.
  */
-export function loadFile(path: string): PerformanceResults {
+export function loadFile(path: string): MeasureResults {
   const contents = fsSync.readFileSync(path, 'utf8');
 
   const lines = contents
@@ -106,18 +106,18 @@ export function loadFile(path: string): PerformanceResults {
     .filter((line) => !!line.trim())
     .map((line) => JSON.parse(line));
 
-  let header: PerformanceHeader | null = null;
-  let entries: PerformanceEntry[] = [];
+  let header: MeasureHeader | null = null;
+  let entries: MeasureEntry[] = [];
 
   const hasHeader = lines[0].metadata !== undefined;
   if (hasHeader) {
     header = parseHeader(lines[0]);
-    entries = parsePerformanceEntries(lines.slice(1));
+    entries = parseMeasureEntries(lines.slice(1));
   } else {
-    entries = parsePerformanceEntries(lines);
+    entries = parseMeasureEntries(lines);
   }
 
-  const keyedEntries: Record<string, PerformanceEntry> = {};
+  const keyedEntries: Record<string, MeasureEntry> = {};
   entries.forEach((entry) => {
     keyedEntries[entry.name] = entry;
   });
@@ -131,7 +131,7 @@ export function loadFile(path: string): PerformanceResults {
 /**
  * Compare results between baseline and current entries and categorize.
  */
-function compareResults(current: PerformanceResults, baseline: PerformanceResults | null): CompareResult {
+function compareResults(current: MeasureResults, baseline: MeasureResults | null): CompareResult {
   // Unique test scenario names
   const names = [...new Set([...Object.keys(current.entries), ...Object.keys(baseline?.entries || {})])];
   const compared: CompareEntry[] = [];
@@ -178,7 +178,7 @@ function compareResults(current: PerformanceResults, baseline: PerformanceResult
 /**
  * Establish statisticial significance of render/execution duration difference build compare entry.
  */
-function buildCompareEntry(name: string, current: PerformanceEntry, baseline: PerformanceEntry): CompareEntry {
+function buildCompareEntry(name: string, current: MeasureEntry, baseline: MeasureEntry): CompareEntry {
   const durationDiff = current.meanDuration - baseline.meanDuration;
   const relativeDurationDiff = durationDiff / baseline.meanDuration;
   const countDiff = current.meanCount - baseline.meanCount;

--- a/packages/compare/src/index.ts
+++ b/packages/compare/src/index.ts
@@ -1,4 +1,13 @@
 export { compare } from './compare';
 export { formatMetadata } from './utils/format';
 
-export type { PerformanceHeader, PerformanceMetadata, PerformanceEntry } from './types';
+export type {
+  PerformanceHeader,
+  PerformanceMetadata,
+  PerformanceEntry,
+  CompareResult,
+  CompareMetadata,
+  CompareEntry,
+  AddedEntry,
+  RemovedEntry,
+} from './types';

--- a/packages/compare/src/index.ts
+++ b/packages/compare/src/index.ts
@@ -2,9 +2,9 @@ export { compare } from './compare';
 export { formatMetadata } from './utils/format';
 
 export type {
-  PerformanceHeader,
-  PerformanceMetadata,
-  PerformanceEntry,
+  MeasureHeader,
+  MeasureMetadata,
+  MeasureEntry,
   CompareResult,
   CompareMetadata,
   CompareEntry,

--- a/packages/compare/src/output/console.ts
+++ b/packages/compare/src/output/console.ts
@@ -1,7 +1,7 @@
 import * as logger from '@callstack/reassure-logger';
 import type { AddedEntry, CompareResult, CompareEntry, RemovedEntry } from '../types';
 import { formatCount, formatDuration, formatMetadata, formatCountChange, formatDurationChange } from '../utils/format';
-import type { PerformanceMetadata } from '../types';
+import type { MeasureMetadata } from '../types';
 
 export function printToConsole(data: CompareResult) {
   // No need to log errors or warnings as these were be logged on the fly
@@ -28,7 +28,7 @@ export function printToConsole(data: CompareResult) {
   logger.newLine();
 }
 
-function printMetadata(name: string, metadata?: PerformanceMetadata) {
+function printMetadata(name: string, metadata?: MeasureMetadata) {
   logger.log(` - ${name}: ${formatMetadata(metadata)}`);
 }
 

--- a/packages/compare/src/output/markdown.ts
+++ b/packages/compare/src/output/markdown.ts
@@ -12,14 +12,7 @@ import {
   formatDurationChange,
 } from '../utils/format';
 import * as md from '../utils/markdown';
-import type {
-  AddedEntry,
-  CompareEntry,
-  CompareResult,
-  RemovedEntry,
-  PerformanceEntry,
-  PerformanceMetadata,
-} from '../types';
+import type { AddedEntry, CompareEntry, CompareResult, RemovedEntry, MeasureEntry, MeasureMetadata } from '../types';
 
 const tableHeader = ['Name', 'Type', 'Duration', 'Count'] as const;
 
@@ -87,7 +80,7 @@ function buildMarkdown(data: CompareResult) {
   return result;
 }
 
-function buildMetadataMarkdown(name: string, metadata: PerformanceMetadata | undefined) {
+function buildMetadataMarkdown(name: string, metadata: MeasureMetadata | undefined) {
   return ` - ${md.bold(name)}: ${formatMetadata(metadata)}`;
 }
 
@@ -146,7 +139,7 @@ function buildCountDetailsEntry(entry: CompareEntry | AddedEntry | RemovedEntry)
     .join('<br/><br/>');
 }
 
-function buildDurationDetails(title: string, entry: PerformanceEntry) {
+function buildDurationDetails(title: string, entry: MeasureEntry) {
   const relativeStdev = entry.stdevDuration / entry.meanDuration;
 
   return [
@@ -159,7 +152,7 @@ function buildDurationDetails(title: string, entry: PerformanceEntry) {
     .join(`<br/>`);
 }
 
-function buildCountDetails(title: string, entry: PerformanceEntry) {
+function buildCountDetails(title: string, entry: MeasureEntry) {
   const relativeStdev = entry.stdevCount / entry.meanCount;
 
   return [

--- a/packages/compare/src/type-schemas.ts
+++ b/packages/compare/src/type-schemas.ts
@@ -1,19 +1,19 @@
 import { z } from 'zod';
 
 /** Metadata information for performance results. */
-export const performanceMetadataSchema = z.object({
+export const MeasureMetadataScheme = z.object({
   branch: z.string().optional(),
   commitHash: z.string().optional(),
   creationDate: z.string().datetime().optional(),
 });
 
 /** Header of performance results file. */
-export const performanceHeaderSchema = z.object({
-  metadata: performanceMetadataSchema,
+export const MeasureHeaderScheme = z.object({
+  metadata: MeasureMetadataScheme,
 });
 
 /** Entry in the performance results file. */
-export const performanceEntrySchema = z.object({
+export const MeasureEntryScheme = z.object({
   /** Name of the test scenario. */
   name: z.string(),
 

--- a/packages/compare/src/types.ts
+++ b/packages/compare/src/types.ts
@@ -1,15 +1,15 @@
 /** Parsed performance results file. */
 import type { z } from 'zod';
-import type { performanceEntrySchema, performanceHeaderSchema, performanceMetadataSchema } from './type-schemas';
+import type { MeasureEntryScheme, MeasureHeaderScheme, MeasureMetadataScheme } from './type-schemas';
 
-export type PerformanceHeader = z.infer<typeof performanceHeaderSchema>;
-export type PerformanceMetadata = z.infer<typeof performanceMetadataSchema>;
-export type PerformanceEntry = z.infer<typeof performanceEntrySchema>;
-export type MeasureType = PerformanceEntry['type'];
+export type MeasureHeader = z.infer<typeof MeasureHeaderScheme>;
+export type MeasureMetadata = z.infer<typeof MeasureMetadataScheme>;
+export type MeasureEntry = z.infer<typeof MeasureEntryScheme>;
+export type MeasureType = MeasureEntry['type'];
 
-export interface PerformanceResults {
-  metadata?: PerformanceMetadata;
-  entries: Record<string, PerformanceEntry>;
+export interface MeasureResults {
+  metadata?: MeasureMetadata;
+  entries: Record<string, MeasureEntry>;
 }
 
 /**
@@ -18,8 +18,8 @@ export interface PerformanceResults {
 export interface CompareEntry {
   name: string;
   type: MeasureType;
-  current: PerformanceEntry;
-  baseline: PerformanceEntry;
+  current: MeasureEntry;
+  baseline: MeasureEntry;
   durationDiff: number;
   relativeDurationDiff: number;
   isDurationDiffSignificant: boolean;
@@ -33,7 +33,7 @@ export interface CompareEntry {
 export interface AddedEntry {
   name: string;
   type: MeasureType;
-  current: PerformanceEntry;
+  current: MeasureEntry;
 }
 
 /**
@@ -42,12 +42,12 @@ export interface AddedEntry {
 export interface RemovedEntry {
   name: string;
   type: MeasureType;
-  baseline: PerformanceEntry;
+  baseline: MeasureEntry;
 }
 
 export interface CompareMetadata {
-  current?: PerformanceMetadata;
-  baseline?: PerformanceMetadata;
+  current?: MeasureMetadata;
+  baseline?: MeasureMetadata;
 }
 
 /** Output of compare function. */

--- a/packages/compare/src/utils/format.ts
+++ b/packages/compare/src/utils/format.ts
@@ -1,5 +1,5 @@
 import { buildRegExp, digit, repeat } from 'ts-regex-builder';
-import type { CompareEntry, PerformanceMetadata } from '../types';
+import type { CompareEntry, MeasureMetadata } from '../types';
 
 /**
  * Utility functions used for formatting data into strings
@@ -99,7 +99,7 @@ function getCountChangeSymbols(entry: CompareEntry) {
   return '';
 }
 
-function formatCommitMetadata(metadata?: PerformanceMetadata) {
+function formatCommitMetadata(metadata?: MeasureMetadata) {
   if (metadata?.branch && metadata?.commitHash) {
     return `${metadata.branch} (${metadata.commitHash})`;
   }
@@ -114,7 +114,7 @@ function formatDateTime(dateString: string) {
   return dateString.replace('T', ' ').replace(isoDateMilliseconds, 'Z');
 }
 
-export function formatMetadata(metadata?: PerformanceMetadata) {
+export function formatMetadata(metadata?: MeasureMetadata) {
   let result = formatCommitMetadata(metadata);
   if (metadata?.creationDate) {
     result += ` - ${formatDateTime(metadata.creationDate)}`;

--- a/packages/compare/src/utils/validate.ts
+++ b/packages/compare/src/utils/validate.ts
@@ -1,19 +1,19 @@
 import { z } from 'zod';
-import { performanceHeaderSchema, performanceEntrySchema } from '../type-schemas';
-import type { PerformanceEntry, PerformanceHeader } from '../types';
+import { MeasureHeaderScheme, MeasureEntryScheme } from '../type-schemas';
+import type { MeasureEntry, MeasureHeader } from '../types';
 import { hasDuplicateValues } from './array';
 
-const performanceEntriesSchema = z
-  .array(performanceEntrySchema)
+const MeasureEntryArraySchema = z
+  .array(MeasureEntryScheme)
   .refine((val) => !hasDuplicateValues(val.map((val) => val.name)), {
     message: `Your performance result file contains records with duplicated names.
     Please remove any non-unique names from your test suites and try again.`,
   });
 
-export function parseHeader(header: unknown): PerformanceHeader | null {
-  return performanceHeaderSchema.parse(header);
+export function parseHeader(header: unknown): MeasureHeader | null {
+  return MeasureHeaderScheme.parse(header);
 }
 
-export function parsePerformanceEntries(entries: unknown): PerformanceEntry[] {
-  return performanceEntriesSchema.parse(entries);
+export function parseMeasureEntries(entries: unknown): MeasureEntry[] {
+  return MeasureEntryArraySchema.parse(entries);
 }

--- a/packages/measure/src/index.ts
+++ b/packages/measure/src/index.ts
@@ -3,3 +3,4 @@ export { measureRenders, measurePerformance } from './measure-renders';
 export { measureFunction } from './measure-function';
 export type { MeasureRendersOptions } from './measure-renders';
 export type { MeasureFunctionOptions } from './measure-function';
+export type { MeasureType, MeasureResults } from './types';

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -182,7 +182,7 @@ A simple version of such script, using a branch-changing approach, is as follows
 #!/usr/bin/env bash
 set -e
 
-BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
+BASELINE_BRANCH=${GITHUB_BASE_REF:="main"}
 
 # Required for `git switch` on CI
 git fetch origin
@@ -255,7 +255,7 @@ A simple version of such script, using a branch-changing approach, is as follows
 #!/usr/bin/env bash
 set -e
 
-BASELINE_BRANCH=${BASELINE_BRANCH:="main"}
+BASELINE_BRANCH=${GITHUB_BASE_REF:="main"}
 
 # Required for `git switch` on CI
 git fetch origin

--- a/packages/reassure/package.json
+++ b/packages/reassure/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/callstack/reassure#readme",
   "dependencies": {
     "@callstack/reassure-cli": "1.0.0-rc.3",
+    "@callstack/reassure-compare": "1.0.0-rc.3",
     "@callstack/reassure-danger": "1.0.0-rc.3",
     "@callstack/reassure-measure": "1.0.0-rc.3",
     "import-local": "^3.1.0"

--- a/packages/reassure/src/index.ts
+++ b/packages/reassure/src/index.ts
@@ -7,4 +7,19 @@ export {
 } from '@callstack/reassure-measure';
 export { dangerReassure } from '@callstack/reassure-danger';
 
-export type { MeasureRendersOptions, MeasureFunctionOptions } from '@callstack/reassure-measure';
+export type {
+  MeasureRendersOptions,
+  MeasureFunctionOptions,
+  MeasureType,
+  MeasureResults,
+} from '@callstack/reassure-measure';
+export type {
+  PerformanceHeader,
+  PerformanceMetadata,
+  PerformanceEntry,
+  CompareResult,
+  CompareMetadata,
+  CompareEntry,
+  AddedEntry,
+  RemovedEntry,
+} from '@callstack/reassure-compare';

--- a/packages/reassure/src/index.ts
+++ b/packages/reassure/src/index.ts
@@ -8,15 +8,15 @@ export {
 export { dangerReassure } from '@callstack/reassure-danger';
 
 export type {
+  MeasureResults,
   MeasureRendersOptions,
   MeasureFunctionOptions,
   MeasureType,
-  MeasureResults,
 } from '@callstack/reassure-measure';
 export type {
-  PerformanceHeader,
-  PerformanceMetadata,
-  PerformanceEntry,
+  MeasureHeader,
+  MeasureMetadata,
+  MeasureEntry,
   CompareResult,
   CompareMetadata,
   CompareEntry,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11235,6 +11235,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.24.1"
     "@babel/runtime": "npm:^7.24.5"
     "@callstack/reassure-cli": "npm:1.0.0-rc.3"
+    "@callstack/reassure-compare": "npm:1.0.0-rc.3"
     "@callstack/reassure-danger": "npm:1.0.0-rc.3"
     "@callstack/reassure-measure": "npm:1.0.0-rc.3"
     "@types/react": "npm:^18.2.46"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Make `reassure` package export more useful types like: `PerformanceHeader`, `PerformanceEntry`, `CompareResult`, etc

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
