### PR TITLE
feat: pass test runner options

### DIFF
--- a/.changeset/tough-ants-shout.md
+++ b/.changeset/tough-ants-shout.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-cli': minor
+---
+
+Passthrough args after -- to Jest

--- a/packages/cli/src/commands/measure.ts
+++ b/packages/cli/src/commands/measure.ts
@@ -56,13 +56,13 @@ export async function run(options: MeasureOptions) {
     return;
   }
 
-  const baseTestRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
-  const passthroughArgs = options._ ?? [];
+  const baseRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
+  const passthroughRunnerArgs = options._ ?? [];
 
   const nodeMajorVersion = getNodeMajorVersion();
   logger.verbose(`Node.js version: ${nodeMajorVersion} (${process.versions.node})`);
 
-  const nodeArgs = [...getNodeFlags(nodeMajorVersion), testRunnerPath, baseTestRunnerArgs, ...passthroughArgs];
+  const nodeArgs = [...getNodeFlags(nodeMajorVersion), testRunnerPath, baseRunnerArgs, ...passthroughRunnerArgs];
   logger.verbose('Running tests using command:');
   logger.verbose(`$ node \\\n    ${nodeArgs.join(' \\\n    ')}\n`);
 

--- a/packages/cli/src/commands/measure.ts
+++ b/packages/cli/src/commands/measure.ts
@@ -47,6 +47,9 @@ export async function run(options: MeasureOptions) {
   const header = { metadata };
   writeFileSync(outputFile, JSON.stringify(header) + '\n');
 
+  const nodeMajorVersion = getNodeMajorVersion();
+  logger.verbose(`Node.js version: ${nodeMajorVersion} (${process.versions.node})`);
+
   const testRunnerPath = process.env.TEST_RUNNER_PATH ?? getJestBinPath();
   if (!testRunnerPath) {
     logger.error(
@@ -56,13 +59,15 @@ export async function run(options: MeasureOptions) {
     return;
   }
 
-  const baseRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
-  const passthroughRunnerArgs = options._ ?? [];
+  const baseTestRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
+  const passthroughTestRunnerArgs = options._ ?? [];
 
-  const nodeMajorVersion = getNodeMajorVersion();
-  logger.verbose(`Node.js version: ${nodeMajorVersion} (${process.versions.node})`);
-
-  const nodeArgs = [...getNodeFlags(nodeMajorVersion), testRunnerPath, baseRunnerArgs, ...passthroughRunnerArgs];
+  const nodeArgs = [
+    ...getNodeFlags(nodeMajorVersion),
+    testRunnerPath,
+    ...baseTestRunnerArgs,
+    ...passthroughTestRunnerArgs,
+  ];
   logger.verbose('Running tests using command:');
   logger.verbose(`$ node \\\n    ${nodeArgs.join(' \\\n    ')}\n`);
 
@@ -147,23 +152,23 @@ export const command: CommandModule<{}, MeasureOptions> = {
   handler: (args) => run(args),
 };
 
-function buildDefaultTestRunnerArgs(options: MeasureOptions) {
+function buildDefaultTestRunnerArgs(options: MeasureOptions): string[] {
   if (options.testMatch && options.testRegex) {
     logger.error('Configuration options "testMatch" and "testRegex" cannot be used together.');
     process.exit(1);
   }
 
-  const commonArgs = '--runInBand';
+  const commonArgs = ['--runInBand'];
 
   if (options.testMatch) {
-    return `${commonArgs} --testMatch=${toShellArray(options.testMatch)}`;
+    return [...commonArgs, `--testMatch=${toShellArray(options.testMatch)}`];
   }
 
   if (options.testRegex) {
-    return `${commonArgs} --testRegex=${toShellArray(options.testRegex)}`;
+    return [...commonArgs, `--testRegex=${toShellArray(options.testRegex)}`];
   }
 
-  return `${commonArgs} --testMatch=${toShellArray(DEFAULT_TEST_MATCH)}`;
+  return [...commonArgs, `--testMatch=${toShellArray(DEFAULT_TEST_MATCH)}`];
 }
 
 function toShellArray(texts: string[]): string {

--- a/packages/cli/src/commands/measure.ts
+++ b/packages/cli/src/commands/measure.ts
@@ -21,7 +21,8 @@ export interface MeasureOptions extends CommonOptions {
   commitHash?: string;
   testMatch?: string[];
   testRegex?: string[];
-  enableWasm?: boolean;
+  /** Rest argument used for flags after `--` separator, will be passed to test runner. */
+  _?: string[];
 }
 
 export async function run(options: MeasureOptions) {
@@ -55,12 +56,13 @@ export async function run(options: MeasureOptions) {
     return;
   }
 
-  const testRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
+  const baseTestRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
+  const passthroughArgs = options._ ?? [];
 
   const nodeMajorVersion = getNodeMajorVersion();
   logger.verbose(`Node.js version: ${nodeMajorVersion} (${process.versions.node})`);
 
-  const nodeArgs = [...getNodeFlags(nodeMajorVersion), testRunnerPath, testRunnerArgs];
+  const nodeArgs = [...getNodeFlags(nodeMajorVersion), testRunnerPath, baseTestRunnerArgs, ...passthroughArgs];
   logger.verbose('Running tests using command:');
   logger.verbose(`$ node \\\n    ${nodeArgs.join(' \\\n    ')}\n`);
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Resolves #294 
Resolves #510 

By providing easy option to forward flags to test runner (Jest by default): `yarn reassure -- --coverage=false`.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Manual testing.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
