### PR TITLE
fix: respect to the "testingLibrary" config option

### DIFF
--- a/.changeset/six-rivers-impress.md
+++ b/.changeset/six-rivers-impress.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-measure': patch
+---
+
+fix: respect to the "testingLibrary" config option

--- a/packages/measure/src/testing-library.ts
+++ b/packages/measure/src/testing-library.ts
@@ -84,7 +84,7 @@ export function resolveTestingLibrary(): TestingLibraryApi {
 
 export function getTestingLibrary(): string | null {
   if (typeof config.testingLibrary === 'string') {
-    config.testingLibrary;
+    return config.testingLibrary;
   }
 
   if (RNTL != null) {


### PR DESCRIPTION
### Summary
I found out that the `testingLibrary` option provided in the config object is not respected in the `getTestingLibrary` function. The function returns 'react-native' no matter what we provide in the configuration.

Looks like the early return statement [accidentally removed or forgotten](https://github.com/callstack/reassure/pull/456/files#diff-9916cc417df3ae60098b0a61764572f50fdaa34c2a738c26eec6a820cc9dfdf5R87) during the v1 effort.

`measureRenderInternals` function relies on `getTestingLibrary` and [runs this code](https://github.com/callstack/reassure/blob/5f9127a1f8d257b08c1b67a9418d63e2a99a54eb/packages/measure/src/measure-renders.tsx#L89) for `react-native`.  It throws an error with `react` testing library, thus this tiny mistake makes `reassure` unusable with `react` testing library. This PR addresses that issue.

### Test plan
Provide `react` as `testingLibrary` config option
Ideally, see if it works with `@testing-library/react` (I don't think there's a setup for that in the repo) 
Or, check if `getTestingLibrary` and `resolveTestingLibrary` functions resolve properly.
