### PR TITLE
fix: passing runner args in CLI

### DIFF
--- a/packages/cli/src/commands/measure.ts
+++ b/packages/cli/src/commands/measure.ts
@@ -59,13 +59,14 @@ export async function run(options: MeasureOptions) {
     return;
   }
 
-  const baseTestRunnerArgs = process.env.TEST_RUNNER_ARGS ?? buildDefaultTestRunnerArgs(options);
+  const baseTestRunnerArgs =
+    process.env.TEST_RUNNER_ARGS !== undefined ? [process.env.TEST_RUNNER_ARGS] : buildDefaultTestRunnerArgs(options);
   const passthroughTestRunnerArgs = options._ ?? [];
 
   const nodeArgs = [
     ...getNodeFlags(nodeMajorVersion),
     testRunnerPath,
-    typeof baseTestRunnerArgs === 'string' ? baseTestRunnerArgs : ...baseTestRunnerArgs,
+    ...baseTestRunnerArgs,
     ...passthroughTestRunnerArgs,
   ];
   logger.verbose('Running tests using command:');

--- a/packages/cli/src/commands/measure.ts
+++ b/packages/cli/src/commands/measure.ts
@@ -65,7 +65,7 @@ export async function run(options: MeasureOptions) {
   const nodeArgs = [
     ...getNodeFlags(nodeMajorVersion),
     testRunnerPath,
-    ...baseTestRunnerArgs,
+    typeof baseTestRunnerArgs === 'string' ? baseTestRunnerArgs : ...baseTestRunnerArgs,
     ...passthroughTestRunnerArgs,
   ];
   logger.verbose('Running tests using command:');


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Passing runner args through CLI doesn’t work, because it’s always passed as a string which is then spread to individual characters. Bug introduced in #511.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Pass custom config through the TEST_RUNNER_PATH env variable.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
