### PR TITLE
refactor: use % threshold for duration diff

### DIFF
--- a/packages/compare/src/compare.ts
+++ b/packages/compare/src/compare.ts
@@ -21,12 +21,10 @@ import { parseHeader, parseMeasureEntries } from './utils/validate';
 const PROBABILITY_CONSIDERED_SIGNIFICANT = 0.02;
 
 /**
- * Duration threshold (in ms) for treating given difference as significant.
- *
+ * Duration threshold (in %) for treating given difference as significant.
  * This is additional filter, in addition to probability threshold above.
- * Too small duration difference might be result of measurement grain of 1 ms.
  */
-const DURATION_DIFF_THRESHOLD_SIGNIFICANT = 4;
+const MIN_SIGNIFICANT_PERCENT_DURATION_THRESHOLD = 0.05; // 5%
 
 /**
  * Threshold for considering render or execution count change as significant. This implies inclusion
@@ -194,7 +192,8 @@ function buildCompareEntry(name: string, current: MeasureEntry, baseline: Measur
   const prob = computeProbability(z);
 
   const isDurationDiffSignificant =
-    prob < PROBABILITY_CONSIDERED_SIGNIFICANT && Math.abs(durationDiff) >= DURATION_DIFF_THRESHOLD_SIGNIFICANT;
+    prob < PROBABILITY_CONSIDERED_SIGNIFICANT &&
+    Math.abs(relativeDurationDiff) >= MIN_SIGNIFICANT_PERCENT_DURATION_THRESHOLD;
 
   return {
     name,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Modify min duration threshold for significant changes from absolute 4ms to relative 5% difference. Results from #534 significantly improving measurement precision.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
