### PR TITLE
feat: add `measureAsyncFunction` function

### DIFF
--- a/.changeset/popular-seahorses-provide.md
+++ b/.changeset/popular-seahorses-provide.md
@@ -1,0 +1,6 @@
+---
+'reassure': minor
+'@callstack/reassure-measure': minor
+---
+
+feat: add measureAsyncFunction

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Allows you to wrap any **asynchronous** function, measure its execution times an
 
 ```ts
 async function measureAsyncFunction(
-  fn: () => Promise<any>,
+  fn: () => Promise<unknown>,
   options?: MeasureAsyncFunctionOptions
 ): Promise<MeasureResults> {
 ```

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ interface MeasureFunctionOptions {
 
 Allows you to wrap any **asynchronous** function, measure its execution times and write results to the output file. You can use optional `options` to customize aspects of the testing. Note: the execution count will always be one.
 
-> **Note**: Measuring asynchronous functions can be useful when, during its execution, they rely or need to get some data from async providers e.g. storage / network and we are purposely disconsidering their impact during the test as we want only to measure the rest of the function's logic. **With that in mind, make sure these providers are properly mocked during test environment so they don't pollute your measurements.**
+> **Note**: Measuring performance of asynchronous functions can be tricky. These functions often depend on external conditions like I/O operations, network requests, or storage access, which introduce unpredictable timing variations in your measurements. For stable and meaningful performance metrics, **always ensure all external calls are properly mocked in your test environment to avoid polluting your performance measurements with uncontrollable factors.**
 
 ```ts
 async function measureAsyncFunction(

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
     - [`MeasureRendersOptions` type](#measurerendersoptions-type)
     - [`measureFunction` function](#measurefunction-function)
     - [`MeasureFunctionOptions` type](#measurefunctionoptions-type)
+    - [`measureAsyncFunction` function](#measureasyncfunction-function)
+    - [`MeasureAsyncFunctionOptions` type](#measureasyncfunctionoptions-type)
   - [Configuration](#configuration)
     - [Default configuration](#default-configuration)
     - [`configure` function](#configure-function)
@@ -397,11 +399,40 @@ async function measureFunction(
 interface MeasureFunctionOptions {
   runs?: number;
   warmupRuns?: number;
+  writeFile?: boolean;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
+- **`writeFile`**: (default `true`) should write output to file.
+
+#### `measureAsyncFunction` function
+
+Allows you to wrap any **asynchronous** function, measure its execution times and write results to the output file. You can use optional `options` to customize aspects of the testing. Note: the execution count will always be one.
+
+> **Note**: Measuring asynchronous functions can be useful when, during its execution, they rely or need to get some data from async providers e.g. storage / network and we are purposely disconsidering their impact during the test as we want only to measure the rest of the function's logic. **With that in mind, make sure these providers are properly mocked during test environment so they don't pollute your measurements.**
+
+```ts
+async function measureAsyncFunction(
+  fn: () => Promise<any>,
+  options?: MeasureAsyncFunctionOptions
+): Promise<MeasureResults> {
+```
+
+#### `MeasureAsyncFunctionOptions` type
+
+```ts
+interface MeasureAsyncFunctionOptions {
+  runs?: number;
+  warmupRuns?: number;
+  writeFile?: boolean;
+}
+```
+
+- **`runs`**: number of runs per series for the particular test
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
+- **`writeFile`**: (default `true`) should write output to file.
 
 ### Configuration
 

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -99,6 +99,53 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
 - **`writeFile`**: (default `true`) should write output to file.
 
+### `measureAsyncFunction` function {#measure-async-function}
+
+Allows you to wrap any **asynchronous** function, measure its performance and write results to the output file. You can use optional `options` to customize aspects of the testing.
+
+:::info
+
+Measuring asynchronous functions can be useful when, during its execution, they rely or need to get some data from async providers e.g. storage / network and we are purposely disconsidering their impact during the test as we want only to measure the rest of the function's logic. **With that in mind, make sure these providers are properly mocked during test environment so they don't pollute your measurements.**
+
+:::
+
+```ts
+async function measureAsyncFunction(
+  fn: () => Promise<any>,
+  options?: MeasureAsyncFunctionOptions,
+): Promise<MeasureResults> {
+```
+
+#### Example {#measure-async-function-example}
+
+```ts
+// sample.perf-test.tsx
+import { measureAsyncFunction } from 'reassure';
+import { fib } from './fib';
+
+test('fib 30', async () => {
+  await measureAsyncFunction(async () => {
+    const asyncLogic = () => Promise.resolve(30);
+    const result = await asyncLogic();
+    fib(result);
+  });
+});
+```
+
+### `MeasureAsyncFunctionOptions` type {#measure-async-function-options}
+
+```ts
+interface MeasureAsyncFunctionOptions {
+  runs?: number;
+  warmupRuns?: number;
+  writeFile?: boolean;
+}
+```
+
+- **`runs`**: number of runs per series for the particular test
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
+- **`writeFile`**: (default `true`) should write output to file.
+
 ## Configuration
 
 ### Default configuration

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -101,11 +101,11 @@ interface MeasureFunctionOptions {
 
 ### `measureAsyncFunction` function {#measure-async-function}
 
-Allows you to wrap any **asynchronous** function, measure its performance and write results to the output file. You can use optional `options` to customize aspects of the testing.
+Allows you to wrap any asynchronous function, measure its performance and write results to the output file. You can use optional `options` to customize aspects of the testing.
 
 :::info
 
-Measuring asynchronous functions can be useful when, during its execution, they rely or need to get some data from async providers e.g. storage / network and we are purposely disconsidering their impact during the test as we want only to measure the rest of the function's logic. **With that in mind, make sure these providers are properly mocked during test environment so they don't pollute your measurements.**
+Measuring performance of asynchronous functions can be tricky. These functions often depend on external conditions like I/O operations, network requests, or storage access, which introduce unpredictable timing variations in your measurements. For stable and meaningful performance metrics, **always ensure all external calls are properly mocked in your test environment to avoid polluting your performance measurements with uncontrollable factors.**
 
 :::
 

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -111,7 +111,7 @@ Measuring performance of asynchronous functions can be tricky. These functions o
 
 ```ts
 async function measureAsyncFunction(
-  fn: () => Promise<any>,
+  fn: () => Promise<unknown>,
   options?: MeasureAsyncFunctionOptions,
 ): Promise<MeasureResults> {
 ```
@@ -125,9 +125,7 @@ import { fib } from './fib';
 
 test('fib 30', async () => {
   await measureAsyncFunction(async () => {
-    const asyncLogic = () => Promise.resolve(30);
-    const result = await asyncLogic();
-    fib(result);
+    return Promise.resolve().then(() => fib(30));
   });
 });
 ```

--- a/packages/compare/src/type-schemas.ts
+++ b/packages/compare/src/type-schemas.ts
@@ -22,8 +22,8 @@ export const MeasureEntryScheme = z.object({
   /** Name of the test scenario. */
   name: z.string(),
 
-  /** Type of the measured characteristic (render, function execution). */
-  type: z.enum(['render', 'function']).default('render'),
+  /** Type of the measured characteristic (render, function execution, async function execution). */
+  type: z.enum(['render', 'function', 'async function']).default('render'),
 
   /** Number of times the measurement test was run. */
   runs: z.number(),

--- a/packages/measure/src/__tests__/measure-function.test.tsx
+++ b/packages/measure/src/__tests__/measure-function.test.tsx
@@ -1,5 +1,6 @@
 import stripAnsi from 'strip-ansi';
 import { measureFunction } from '../measure-function';
+import { measureAsyncFunction } from '../measure-async-function';
 import { setHasShownFlagsOutput } from '../output';
 
 // Exponentially slow function
@@ -14,6 +15,19 @@ function fib(n: number): number {
 test('measureFunction captures results', async () => {
   const fn = jest.fn(() => fib(5));
   const results = await measureFunction(fn, { runs: 1, warmupRuns: 0, writeFile: false });
+
+  expect(fn).toHaveBeenCalledTimes(1);
+  expect(results.runs).toBe(1);
+  expect(results.counts).toEqual([1]);
+});
+
+test('measureAsyncFunction captures results', async () => {
+  const fn = jest.fn(async () => {
+    const asyncLogic = () => Promise.resolve(5);
+    const result = await asyncLogic();
+    fib(result);
+  });
+  const results = await measureAsyncFunction(fn, { runs: 1, warmupRuns: 0, writeFile: false });
 
   expect(fn).toHaveBeenCalledTimes(1);
   expect(results.runs).toBe(1);

--- a/packages/measure/src/__tests__/measure-function.test.tsx
+++ b/packages/measure/src/__tests__/measure-function.test.tsx
@@ -23,9 +23,8 @@ test('measureFunction captures results', async () => {
 
 test('measureAsyncFunction captures results', async () => {
   const fn = jest.fn(async () => {
-    const asyncLogic = () => Promise.resolve(5);
-    const result = await asyncLogic();
-    fib(result);
+    await Promise.resolve();
+    return fib(5);
   });
   const results = await measureAsyncFunction(fn, { runs: 1, warmupRuns: 0, writeFile: false });
 

--- a/packages/measure/src/index.ts
+++ b/packages/measure/src/index.ts
@@ -1,6 +1,8 @@
 export { configure, resetToDefaults } from './config';
 export { measureRenders, measurePerformance } from './measure-renders';
 export { measureFunction } from './measure-function';
+export { measureAsyncFunction } from './measure-async-function';
 export type { MeasureRendersOptions } from './measure-renders';
 export type { MeasureFunctionOptions } from './measure-function';
+export type { MeasureAsyncFunctionOptions } from './measure-async-function';
 export type { MeasureType, MeasureResults } from './types';

--- a/packages/measure/src/measure-async-function.tsx
+++ b/packages/measure/src/measure-async-function.tsx
@@ -7,7 +7,7 @@ import { MeasureFunctionOptions } from './measure-function';
 export interface MeasureAsyncFunctionOptions extends MeasureFunctionOptions {}
 
 export async function measureAsyncFunction(
-  fn: () => Promise<any>,
+  fn: () => Promise<unknown>,
   options?: MeasureAsyncFunctionOptions
 ): Promise<MeasureResults> {
   const stats = await measureAsyncFunctionInternal(fn, options);
@@ -20,7 +20,7 @@ export async function measureAsyncFunction(
 }
 
 async function measureAsyncFunctionInternal(
-  fn: () => Promise<any>,
+  fn: () => Promise<unknown>,
   options?: MeasureAsyncFunctionOptions
 ): Promise<MeasureResults> {
   const runs = options?.runs ?? config.runs;

--- a/packages/measure/src/measure-async-function.tsx
+++ b/packages/measure/src/measure-async-function.tsx
@@ -2,15 +2,15 @@ import { config } from './config';
 import type { MeasureResults } from './types';
 import { type RunResult, getCurrentTime, processRunResults } from './measure-helpers';
 import { showFlagsOutputIfNeeded, writeTestStats } from './output';
+import { MeasureFunctionOptions } from './measure-function';
 
-export interface MeasureFunctionOptions {
-  runs?: number;
-  warmupRuns?: number;
-  writeFile?: boolean;
-}
+export interface MeasureAsyncFunctionOptions extends MeasureFunctionOptions {}
 
-export async function measureFunction(fn: () => void, options?: MeasureFunctionOptions): Promise<MeasureResults> {
-  const stats = measureFunctionInternal(fn, options);
+export async function measureAsyncFunction(
+  fn: () => Promise<any>,
+  options?: MeasureAsyncFunctionOptions
+): Promise<MeasureResults> {
+  const stats = await measureAsyncFunctionInternal(fn, options);
 
   if (options?.writeFile !== false) {
     await writeTestStats(stats, 'function');
@@ -19,7 +19,10 @@ export async function measureFunction(fn: () => void, options?: MeasureFunctionO
   return stats;
 }
 
-function measureFunctionInternal(fn: () => void, options?: MeasureFunctionOptions): MeasureResults {
+async function measureAsyncFunctionInternal(
+  fn: () => Promise<any>,
+  options?: MeasureAsyncFunctionOptions
+): Promise<MeasureResults> {
   const runs = options?.runs ?? config.runs;
   const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
 
@@ -28,7 +31,7 @@ function measureFunctionInternal(fn: () => void, options?: MeasureFunctionOption
   const runResults: RunResult[] = [];
   for (let i = 0; i < runs + warmupRuns; i += 1) {
     const timeStart = getCurrentTime();
-    fn();
+    await fn();
     const timeEnd = getCurrentTime();
 
     const duration = timeEnd - timeStart;

--- a/packages/measure/src/measure-async-function.tsx
+++ b/packages/measure/src/measure-async-function.tsx
@@ -13,7 +13,7 @@ export async function measureAsyncFunction(
   const stats = await measureAsyncFunctionInternal(fn, options);
 
   if (options?.writeFile !== false) {
-    await writeTestStats(stats, 'function');
+    await writeTestStats(stats, 'async function');
   }
 
   return stats;

--- a/packages/measure/src/measure-helpers.tsx
+++ b/packages/measure/src/measure-helpers.tsx
@@ -1,9 +1,14 @@
+import { performance } from 'perf_hooks';
 import * as math from 'mathjs';
 import type { MeasureResults } from './types';
 
 export interface RunResult {
   duration: number;
   count: number;
+}
+
+export function getCurrentTime() {
+  return performance.now();
 }
 
 export function processRunResults(inputResults: RunResult[], warmupRuns: number): MeasureResults {

--- a/packages/measure/src/types.ts
+++ b/packages/measure/src/types.ts
@@ -1,5 +1,5 @@
 /** Type of measured performance characteristic. */
-export type MeasureType = 'render' | 'function';
+export type MeasureType = 'render' | 'function' | 'async function';
 
 /**
  * Type representing the result of `measure*` functions.

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -415,7 +415,7 @@ Allows you to wrap any **asynchronous** function, measure its execution times an
 
 ```ts
 async function measureAsyncFunction(
-  fn: () => Promise<any>,
+  fn: () => Promise<unknown>,
   options?: MeasureAsyncFunctionOptions
 ): Promise<MeasureResults> {
 ```

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -411,7 +411,7 @@ interface MeasureFunctionOptions {
 
 Allows you to wrap any **asynchronous** function, measure its execution times and write results to the output file. You can use optional `options` to customize aspects of the testing. Note: the execution count will always be one.
 
-> **Note**: Measuring asynchronous functions can be useful when, during its execution, they rely or need to get some data from async providers e.g. storage / network and we are purposely disconsidering their impact during the test as we want only to measure the rest of the function's logic. **With that in mind, make sure these providers are properly mocked during test environment so they don't pollute your measurements.**
+> **Note**: Measuring performance of asynchronous functions can be tricky. These functions often depend on external conditions like I/O operations, network requests, or storage access, which introduce unpredictable timing variations in your measurements. For stable and meaningful performance metrics, **always ensure all external calls are properly mocked in your test environment to avoid polluting your performance measurements with uncontrollable factors.**
 
 ```ts
 async function measureAsyncFunction(

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -43,6 +43,8 @@
     - [`MeasureRendersOptions` type](#measurerendersoptions-type)
     - [`measureFunction` function](#measurefunction-function)
     - [`MeasureFunctionOptions` type](#measurefunctionoptions-type)
+    - [`measureAsyncFunction` function](#measureasyncfunction-function)
+    - [`MeasureAsyncFunctionOptions` type](#measureasyncfunctionoptions-type)
   - [Configuration](#configuration)
     - [Default configuration](#default-configuration)
     - [`configure` function](#configure-function)
@@ -397,11 +399,40 @@ async function measureFunction(
 interface MeasureFunctionOptions {
   runs?: number;
   warmupRuns?: number;
+  writeFile?: boolean;
 }
 ```
 
 - **`runs`**: number of runs per series for the particular test
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
+- **`writeFile`**: (default `true`) should write output to file.
+
+#### `measureAsyncFunction` function
+
+Allows you to wrap any **asynchronous** function, measure its execution times and write results to the output file. You can use optional `options` to customize aspects of the testing. Note: the execution count will always be one.
+
+> **Note**: Measuring asynchronous functions can be useful when, during its execution, they rely or need to get some data from async providers e.g. storage / network and we are purposely disconsidering their impact during the test as we want only to measure the rest of the function's logic. **With that in mind, make sure these providers are properly mocked during test environment so they don't pollute your measurements.**
+
+```ts
+async function measureAsyncFunction(
+  fn: () => Promise<any>,
+  options?: MeasureAsyncFunctionOptions
+): Promise<MeasureResults> {
+```
+
+#### `MeasureAsyncFunctionOptions` type
+
+```ts
+interface MeasureAsyncFunctionOptions {
+  runs?: number;
+  warmupRuns?: number;
+  writeFile?: boolean;
+}
+```
+
+- **`runs`**: number of runs per series for the particular test
+- **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs.
+- **`writeFile`**: (default `true`) should write output to file.
 
 ### Configuration
 

--- a/packages/reassure/src/index.ts
+++ b/packages/reassure/src/index.ts
@@ -1,6 +1,7 @@
 export {
   measureRenders,
   measureFunction,
+  measureAsyncFunction,
   configure,
   resetToDefaults,
   measurePerformance,
@@ -11,6 +12,7 @@ export type {
   MeasureResults,
   MeasureRendersOptions,
   MeasureFunctionOptions,
+  MeasureAsyncFunctionOptions,
   MeasureType,
 } from '@callstack/reassure-measure';
 export type {

--- a/test-apps/native/src/fib.perf.tsx
+++ b/test-apps/native/src/fib.perf.tsx
@@ -18,8 +18,20 @@ describe('`fib` function', () => {
     await measureFunction(() => fib(30));
   });
 
+  test('fib(30) async', async () => {
+    await measureAsyncFunction(async () =>
+      Promise.resolve().then(() => fib(30)),
+    );
+  });
+
   test('fib(31)', async () => {
     await measureFunction(() => fib(31));
+  });
+
+  test('fib(31) async', async () => {
+    await measureAsyncFunction(async () =>
+      Promise.resolve().then(() => fib(31)),
+    );
   });
 
   test('fib(32)', async () => {
@@ -27,10 +39,8 @@ describe('`fib` function', () => {
   });
 
   test('fib(32) async', async () => {
-    await measureAsyncFunction(async () => {
-      const asyncLogic = () => Promise.resolve(32);
-      const result = await asyncLogic();
-      fib(result);
-    });
+    await measureAsyncFunction(async () =>
+      Promise.resolve().then(() => fib(32)),
+    );
   });
 });

--- a/test-apps/native/src/fib.perf.tsx
+++ b/test-apps/native/src/fib.perf.tsx
@@ -1,4 +1,7 @@
-import { measureFunction } from '@callstack/reassure-measure';
+import {
+  measureFunction,
+  measureAsyncFunction,
+} from '@callstack/reassure-measure';
 
 function fib(n: number): number {
   if (n <= 1) {
@@ -21,5 +24,13 @@ describe('`fib` function', () => {
 
   test('fib(32)', async () => {
     await measureFunction(() => fib(32));
+  });
+
+  test('fib(32) async', async () => {
+    await measureAsyncFunction(async () => {
+      const asyncLogic = () => Promise.resolve(32);
+      const result = await asyncLogic();
+      fib(result);
+    });
   });
 });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR adds the `measureAsyncFunction` function, which enable consumers to measure the performance of async functions.

### Test plan

Unit tests were added to cover this change.
