### PR TITLE
feat: add support for setup/cleanup functions during each test run

### DIFF
--- a/.changeset/silent-cups-fail.md
+++ b/.changeset/silent-cups-fail.md
@@ -1,0 +1,6 @@
+---
+'reassure': minor
+'@callstack/reassure-measure': minor
+---
+
+feat: add support for setup/cleanup functions during each test run

--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -383,6 +385,8 @@ interface MeasureRendersOptions {
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results; only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the UI by utilising RNTL or RTL functions
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 #### `measureFunction` function
 
@@ -403,6 +407,8 @@ interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -410,6 +416,8 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 #### `measureAsyncFunction` function
 
@@ -432,6 +440,8 @@ interface MeasureAsyncFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -439,6 +449,8 @@ interface MeasureAsyncFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -385,8 +385,8 @@ interface MeasureRendersOptions {
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results; only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the UI by utilising RNTL or RTL functions
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 #### `measureFunction` function
 
@@ -407,8 +407,8 @@ interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -416,8 +416,8 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 #### `measureAsyncFunction` function
 
@@ -440,8 +440,8 @@ interface MeasureAsyncFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -449,8 +449,8 @@ interface MeasureAsyncFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 ### Configuration
 

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -64,7 +64,7 @@ interface MeasureRendersOptions {
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
-- **`writeFile`**: (default `true`) should write output to file.
+- **`writeFile`**: should write output to file (default `true`)
 - **`beforeEach`**: function to execute before each test run.
 - **`afterEach`**: function to execute after each test run.
 

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -54,6 +54,8 @@ interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -62,7 +64,9 @@ interface MeasureRendersOptions {
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
-- **`writeFile`**: should write output to file (default `true`)
+- **`writeFile`**: (default `true`) should write output to file.
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 ### `measureFunction` function {#measure-function}
 
@@ -95,6 +99,8 @@ interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -102,6 +108,8 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 ### `measureAsyncFunction` function {#measure-async-function}
 
@@ -142,6 +150,8 @@ interface MeasureAsyncFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -149,6 +159,8 @@ interface MeasureAsyncFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: (default `true`) should write output to file
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 ## Configuration
 

--- a/docusaurus/docs/api.md
+++ b/docusaurus/docs/api.md
@@ -54,8 +54,8 @@ interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -65,8 +65,8 @@ interface MeasureRendersOptions {
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results, only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the ui by utilized RNTL functions
 - **`writeFile`**: (default `true`) should write output to file.
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 ### `measureFunction` function {#measure-function}
 
@@ -99,8 +99,8 @@ interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -108,8 +108,8 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 ### `measureAsyncFunction` function {#measure-async-function}
 
@@ -150,8 +150,8 @@ interface MeasureAsyncFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -159,8 +159,8 @@ interface MeasureAsyncFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: (default `true`) should write output to file
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 ## Configuration
 

--- a/packages/measure/src/__tests__/measure-async-function.test.tsx
+++ b/packages/measure/src/__tests__/measure-async-function.test.tsx
@@ -45,6 +45,26 @@ test('measureAsyncFunction applies "warmupRuns" option', async () => {
   expect(results.stdevCount).toBe(0);
 });
 
+test('measureAsyncFunction executes setup and cleanup functions for each run', async () => {
+  const fn = jest.fn(() => Promise.resolve().then(() => fib(5)));
+  const beforeFn = jest.fn();
+  const afterFn = jest.fn();
+  const results = await measureAsyncFunction(fn, {
+    runs: 10,
+    warmupRuns: 1,
+    writeFile: false,
+    beforeEach: beforeFn,
+    afterEach: afterFn,
+  });
+
+  expect(beforeFn).toHaveBeenCalledTimes(11);
+  expect(fn).toHaveBeenCalledTimes(11);
+  expect(afterFn).toHaveBeenCalledTimes(11);
+  expect(results.runs).toBe(10);
+  expect(results.durations.length + (results.outlierDurations?.length ?? 0)).toBe(10);
+  expect(results.counts).toHaveLength(10);
+});
+
 const errorsToIgnore = ['❌ Measure code is running under incorrect Node.js configuration.'];
 const realConsole = jest.requireActual('console') as Console;
 

--- a/packages/measure/src/__tests__/measure-function.test.tsx
+++ b/packages/measure/src/__tests__/measure-function.test.tsx
@@ -73,30 +73,7 @@ test('measureFunction executes setup and cleanup functions for each run', async 
   expect(fn).toHaveBeenCalledTimes(11);
   expect(afterFn).toHaveBeenCalledTimes(11);
   expect(results.runs).toBe(10);
-  expect(results.durations).toHaveLength(10);
-  expect(results.counts).toHaveLength(10);
-});
-
-test('measureAsyncFunction executes setup and cleanup functions for each run', async () => {
-  const fn = jest.fn(async () => {
-    await Promise.resolve();
-    return fib(5);
-  });
-  const beforeFn = jest.fn();
-  const afterFn = jest.fn();
-  const results = await measureAsyncFunction(fn, {
-    runs: 10,
-    warmupRuns: 1,
-    writeFile: false,
-    beforeEach: beforeFn,
-    afterEach: afterFn,
-  });
-
-  expect(beforeFn).toHaveBeenCalledTimes(11);
-  expect(fn).toHaveBeenCalledTimes(11);
-  expect(afterFn).toHaveBeenCalledTimes(11);
-  expect(results.runs).toBe(10);
-  expect(results.durations).toHaveLength(10);
+  expect(results.durations.length + (results.outlierDurations?.length ?? 0)).toBe(10);
   expect(results.counts).toHaveLength(10);
 });
 

--- a/packages/measure/src/__tests__/measure-function.test.tsx
+++ b/packages/measure/src/__tests__/measure-function.test.tsx
@@ -57,6 +57,49 @@ test('measureFunction applies "warmupRuns" option', async () => {
   expect(results.stdevCount).toBe(0);
 });
 
+test('measureFunction executes setup and cleanup functions for each run', async () => {
+  const fn = jest.fn(() => fib(5));
+  const beforeFn = jest.fn();
+  const afterFn = jest.fn();
+  const results = await measureFunction(fn, {
+    runs: 10,
+    warmupRuns: 1,
+    writeFile: false,
+    beforeEachRun: beforeFn,
+    afterEachRun: afterFn,
+  });
+
+  expect(beforeFn).toHaveBeenCalledTimes(11);
+  expect(fn).toHaveBeenCalledTimes(11);
+  expect(afterFn).toHaveBeenCalledTimes(11);
+  expect(results.runs).toBe(10);
+  expect(results.durations).toHaveLength(10);
+  expect(results.counts).toHaveLength(10);
+});
+
+test('measureAsyncFunction executes setup and cleanup functions for each run', async () => {
+  const fn = jest.fn(async () => {
+    await Promise.resolve();
+    return fib(5);
+  });
+  const beforeFn = jest.fn();
+  const afterFn = jest.fn();
+  const results = await measureAsyncFunction(fn, {
+    runs: 10,
+    warmupRuns: 1,
+    writeFile: false,
+    beforeEachRun: beforeFn,
+    afterEachRun: afterFn,
+  });
+
+  expect(beforeFn).toHaveBeenCalledTimes(11);
+  expect(fn).toHaveBeenCalledTimes(11);
+  expect(afterFn).toHaveBeenCalledTimes(11);
+  expect(results.runs).toBe(10);
+  expect(results.durations).toHaveLength(10);
+  expect(results.counts).toHaveLength(10);
+});
+
 const errorsToIgnore = ['❌ Measure code is running under incorrect Node.js configuration.'];
 const realConsole = jest.requireActual('console') as Console;
 

--- a/packages/measure/src/__tests__/measure-function.test.tsx
+++ b/packages/measure/src/__tests__/measure-function.test.tsx
@@ -65,8 +65,8 @@ test('measureFunction executes setup and cleanup functions for each run', async 
     runs: 10,
     warmupRuns: 1,
     writeFile: false,
-    beforeEachRun: beforeFn,
-    afterEachRun: afterFn,
+    beforeEach: beforeFn,
+    afterEach: afterFn,
   });
 
   expect(beforeFn).toHaveBeenCalledTimes(11);
@@ -88,8 +88,8 @@ test('measureAsyncFunction executes setup and cleanup functions for each run', a
     runs: 10,
     warmupRuns: 1,
     writeFile: false,
-    beforeEachRun: beforeFn,
-    afterEachRun: afterFn,
+    beforeEach: beforeFn,
+    afterEach: afterFn,
   });
 
   expect(beforeFn).toHaveBeenCalledTimes(11);

--- a/packages/measure/src/__tests__/measure-renders.test.tsx
+++ b/packages/measure/src/__tests__/measure-renders.test.tsx
@@ -57,8 +57,6 @@ test('measureRenders executes setup and cleanup functions for each run', async (
   expect(results.runs).toBe(10);
   expect(results.durations).toHaveLength(10);
   expect(results.counts).toHaveLength(10);
-  expect(results.meanCount).toBe(1);
-  expect(results.stdevCount).toBe(0);
 });
 
 test('measureRenders should log error when running under incorrect node flags', async () => {

--- a/packages/measure/src/__tests__/measure-renders.test.tsx
+++ b/packages/measure/src/__tests__/measure-renders.test.tsx
@@ -38,6 +38,29 @@ test('measureRenders applies "warmupRuns" option', async () => {
   expect(results.stdevCount).toBe(0);
 });
 
+test('measureRenders executes setup and cleanup functions for each run', async () => {
+  const scenario = jest.fn(() => Promise.resolve(null));
+  const beforeFn = jest.fn();
+  const afterFn = jest.fn();
+  const results = await measureRenders(<View />, {
+    runs: 10,
+    warmupRuns: 1,
+    scenario,
+    writeFile: false,
+    beforeEachRun: beforeFn,
+    afterEachRun: afterFn,
+  });
+
+  expect(beforeFn).toHaveBeenCalledTimes(11);
+  expect(scenario).toHaveBeenCalledTimes(11);
+  expect(afterFn).toHaveBeenCalledTimes(11);
+  expect(results.runs).toBe(10);
+  expect(results.durations).toHaveLength(10);
+  expect(results.counts).toHaveLength(10);
+  expect(results.meanCount).toBe(1);
+  expect(results.stdevCount).toBe(0);
+});
+
 test('measureRenders should log error when running under incorrect node flags', async () => {
   jest.spyOn(realConsole, 'error').mockImplementation((message) => {
     if (!errorsToIgnore.some((error) => message.includes(error))) {

--- a/packages/measure/src/__tests__/measure-renders.test.tsx
+++ b/packages/measure/src/__tests__/measure-renders.test.tsx
@@ -47,8 +47,8 @@ test('measureRenders executes setup and cleanup functions for each run', async (
     warmupRuns: 1,
     scenario,
     writeFile: false,
-    beforeEachRun: beforeFn,
-    afterEachRun: afterFn,
+    beforeEach: beforeFn,
+    afterEach: afterFn,
   });
 
   expect(beforeFn).toHaveBeenCalledTimes(11);

--- a/packages/measure/src/__tests__/measure-renders.test.tsx
+++ b/packages/measure/src/__tests__/measure-renders.test.tsx
@@ -55,7 +55,7 @@ test('measureRenders executes setup and cleanup functions for each run', async (
   expect(scenario).toHaveBeenCalledTimes(11);
   expect(afterFn).toHaveBeenCalledTimes(11);
   expect(results.runs).toBe(10);
-  expect(results.durations).toHaveLength(10);
+  expect(results.durations.length + (results.outlierDurations?.length ?? 0)).toBe(10);
   expect(results.counts).toHaveLength(10);
 });
 

--- a/packages/measure/src/measure-async-function.tsx
+++ b/packages/measure/src/measure-async-function.tsx
@@ -31,9 +31,13 @@ async function measureAsyncFunctionInternal(
 
   const runResults: RunResult[] = [];
   for (let i = 0; i < runs + warmupRuns; i += 1) {
+    await options?.beforeEachRun?.();
+
     const timeStart = getCurrentTime();
     await fn();
     const timeEnd = getCurrentTime();
+
+    await options?.afterEachRun?.();
 
     const duration = timeEnd - timeStart;
     runResults.push({ duration, count: 1 });

--- a/packages/measure/src/measure-async-function.tsx
+++ b/packages/measure/src/measure-async-function.tsx
@@ -31,13 +31,13 @@ async function measureAsyncFunctionInternal(
 
   const runResults: RunResult[] = [];
   for (let i = 0; i < runs + warmupRuns; i += 1) {
-    await options?.beforeEachRun?.();
+    await options?.beforeEach?.();
 
     const timeStart = getCurrentTime();
     await fn();
     const timeEnd = getCurrentTime();
 
-    await options?.afterEachRun?.();
+    await options?.afterEach?.();
 
     const duration = timeEnd - timeStart;
     runResults.push({ duration, count: 1 });

--- a/packages/measure/src/measure-function.tsx
+++ b/packages/measure/src/measure-function.tsx
@@ -8,8 +8,8 @@ export interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 
 export async function measureFunction(fn: () => void, options?: MeasureFunctionOptions): Promise<MeasureResults> {
@@ -31,13 +31,13 @@ async function measureFunctionInternal(fn: () => void, options?: MeasureFunction
 
   const runResults: RunResult[] = [];
   for (let i = 0; i < runs + warmupRuns; i += 1) {
-    await options?.beforeEachRun?.();
+    await options?.beforeEach?.();
 
     const timeStart = getCurrentTime();
     fn();
     const timeEnd = getCurrentTime();
 
-    await options?.afterEachRun?.();
+    await options?.afterEach?.();
 
     const duration = timeEnd - timeStart;
     runResults.push({ duration, count: 1 });

--- a/packages/measure/src/measure-renders.tsx
+++ b/packages/measure/src/measure-renders.tsx
@@ -20,6 +20,8 @@ export interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: React.ReactElement }>;
   scenario?: (screen: any) => Promise<any>;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 
 export async function measureRenders(
@@ -69,6 +71,8 @@ async function measureRendersInternal(
   let initialRenderCount = 0;
 
   for (let iteration = 0; iteration < runs + warmupRuns; iteration += 1) {
+    await options?.beforeEachRun?.();
+
     let duration = 0;
     let count = 0;
     let renderResult: any = null;
@@ -107,6 +111,8 @@ async function measureRendersInternal(
 
     cleanup();
     global.gc?.();
+
+    await options?.afterEachRun?.();
 
     runResults.push({ duration, count });
   }

--- a/packages/measure/src/measure-renders.tsx
+++ b/packages/measure/src/measure-renders.tsx
@@ -20,8 +20,8 @@ export interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: React.ReactElement }>;
   scenario?: (screen: any) => Promise<any>;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 
 export async function measureRenders(
@@ -71,7 +71,7 @@ async function measureRendersInternal(
   let initialRenderCount = 0;
 
   for (let iteration = 0; iteration < runs + warmupRuns; iteration += 1) {
-    await options?.beforeEachRun?.();
+    await options?.beforeEach?.();
 
     let duration = 0;
     let count = 0;
@@ -112,7 +112,7 @@ async function measureRendersInternal(
     cleanup();
     global.gc?.();
 
-    await options?.afterEachRun?.();
+    await options?.afterEach?.();
 
     runResults.push({ duration, count });
   }

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -374,6 +374,8 @@ interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -383,6 +385,8 @@ interface MeasureRendersOptions {
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results; only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the UI by utilising RNTL or RTL functions
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 #### `measureFunction` function
 
@@ -403,6 +407,8 @@ interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -410,6 +416,8 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 #### `measureAsyncFunction` function
 
@@ -432,6 +440,8 @@ interface MeasureAsyncFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
+  beforeEachRun?: () => Promise<void> | void;
+  afterEachRun?: () => Promise<void> | void;
 }
 ```
 
@@ -439,6 +449,8 @@ interface MeasureAsyncFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
+- **`beforeEachRun`**: function to execute before each test run.
+- **`afterEachRun`**: function to execute after each test run.
 
 ### Configuration
 

--- a/packages/reassure/README.md
+++ b/packages/reassure/README.md
@@ -374,8 +374,8 @@ interface MeasureRendersOptions {
   wrapper?: React.ComponentType<{ children: ReactElement }>;
   scenario?: (view?: RenderResult) => Promise<any>;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -385,8 +385,8 @@ interface MeasureRendersOptions {
 - **`wrapper`**: React component, such as a `Provider`, which the `ui` will be wrapped with. Note: the render duration of the `wrapper` itself is excluded from the results; only the wrapped component is measured.
 - **`scenario`**: a custom async function, which defines user interaction within the UI by utilising RNTL or RTL functions
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 #### `measureFunction` function
 
@@ -407,8 +407,8 @@ interface MeasureFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -416,8 +416,8 @@ interface MeasureFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 #### `measureAsyncFunction` function
 
@@ -440,8 +440,8 @@ interface MeasureAsyncFunctionOptions {
   warmupRuns?: number;
   removeOutliers?: boolean;
   writeFile?: boolean;
-  beforeEachRun?: () => Promise<void> | void;
-  afterEachRun?: () => Promise<void> | void;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
 }
 ```
 
@@ -449,8 +449,8 @@ interface MeasureAsyncFunctionOptions {
 - **`warmupRuns`**: number of additional warmup runs that will be done and discarded before the actual runs
 - **`removeOutliers`**: should remove statistical outlier results (default: `true`)
 - **`writeFile`**: should write output to file (default `true`)
-- **`beforeEachRun`**: function to execute before each test run.
-- **`afterEachRun`**: function to execute after each test run.
+- **`beforeEach`**: function to execute before each test run.
+- **`afterEach`**: function to execute after each test run.
 
 ### Configuration
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR adds the `beforeEachRun` and `afterEachRun` options for `measureFunction`, `measureAsyncFunction` and `measureRenders` functions, allowing to specify setup/cleanup functions during each test run.

### Test plan

Unit tests were added to cover this feature.
