### PR TITLE
Truncate "meanCount" and "stdCount" results

### DIFF
--- a/packages/measure/src/__tests__/measure-helpers.test.ts
+++ b/packages/measure/src/__tests__/measure-helpers.test.ts
@@ -3,7 +3,7 @@ import { processRunResults } from '../measure-helpers';
 test('processRunResults calculates correct means and stdevs', () => {
   const input = [
     { duration: 10, count: 2 },
-    { duration: 12, count: 2 },
+    { duration: 12, count: 3 },
     { duration: 14, count: 2 },
   ];
 
@@ -11,7 +11,7 @@ test('processRunResults calculates correct means and stdevs', () => {
     {
       "counts": [
         2,
-        2,
+        3,
         2,
       ],
       "durations": [
@@ -34,7 +34,7 @@ test('processRunResults applies warmupRuns option', () => {
   const input = [
     { duration: 23, count: 1 },
     { duration: 20, count: 5 },
-    { duration: 24, count: 5 },
+    { duration: 24, count: 6 },
     { duration: 22, count: 5 },
   ];
 
@@ -42,7 +42,7 @@ test('processRunResults applies warmupRuns option', () => {
     {
       "counts": [
         5,
-        5,
+        6,
         5,
       ],
       "durations": [

--- a/packages/measure/src/measure-helpers.tsx
+++ b/packages/measure/src/measure-helpers.tsx
@@ -26,8 +26,8 @@ export function processRunResults(inputResults: RunResult[], options: ProcessRun
   const outlierDurations = outliers?.map((result) => result.duration);
 
   const counts = runResults.map((result) => result.count);
-  const meanCount = math.mean(...counts) as number;
-  const stdevCount = math.std(...counts);
+  const meanCount = math.fix(math.mean(...counts)) as number;
+  const stdevCount = math.fix(math.std(...counts));
 
   return {
     runs: runResults.length,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Some component (example: [AsyncComponent.tsx](https://github.com/callstack/reassure-examples/blob/main/examples/web-vite/src/AsyncComponent.tsx)) can have different render counts due to its nature or behavior during tests. Currently these difference in render counts between baseline and delta will lead to decimal `meanCount` and `stdCount` results, which don't quite make sense since we are talking about renders (there are no "decimal" renders). This PR fix the result data by truncating these properties.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Make sure unit tests pass.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
