### PR TITLE
refactor: use renderAsync for RNTL (WIP)

### DIFF
--- a/packages/compare/src/test/__snapshots__/compare.test.ts.snap
+++ b/packages/compare/src/test/__snapshots__/compare.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`loadFile should fail for file with invalid JSON structure 1`] = `"Unexpected non-whitespace character after JSON at position 6"`;
+exports[`loadFile should fail for file with invalid JSON structure 1`] = `"Unexpected non-whitespace character after JSON at position 6 (line 1 column 7)"`;
 
 exports[`loadFile should fail for file with invalid entry 1`] = `
 "[

--- a/packages/compare/src/test/__snapshots__/compare.test.ts.snap
+++ b/packages/compare/src/test/__snapshots__/compare.test.ts.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loadFile should fail for file with invalid JSON structure 1`] = `"Unexpected non-whitespace character after JSON at position 6 (line 1 column 7)"`;
+exports[`loadFile should fail for file with invalid JSON structure 1`] = `"Unexpected non-whitespace character after JSON at position 6"`;
 
 exports[`loadFile should fail for file with invalid entry 1`] = `
 "[

--- a/packages/measure/package.json
+++ b/packages/measure/package.json
@@ -48,7 +48,7 @@
     "@babel/runtime": "^7.26.9",
     "@relmify/jest-serializer-strip-ansi": "^1.0.2",
     "@testing-library/react": "^16.2.0",
-    "@testing-library/react-native": "^13.2.0",
+    "@testing-library/react-native": "^13.3.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.0.0",
     "babel-jest": "^30.0.2",
@@ -63,7 +63,13 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
+    "@react-native/testing-library": "^13.3.0",
     "react": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@react-native/testing-library": {
+      "optional": true
+    }
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/measure/src/__tests__/measure-renders.test.tsx
+++ b/packages/measure/src/__tests__/measure-renders.test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { fireEvent, screen } from '@testing-library/react-native';
 import stripAnsi from 'strip-ansi';
-import { buildUiToRender, measureRenders } from '../measure-renders';
+import { measureRenders } from '../measure-renders';
+import { buildUiToRender } from '../measure-renders-common';
 import { setHasShownFlagsOutput } from '../output';
 
 const errorsToIgnore = ['❌ Measure code is running under incorrect Node.js configuration.'];
@@ -225,9 +226,9 @@ const AsyncMicrotaskEffect = () => {
   );
 };
 
-test('ignores async micro-tasks effect', async () => {
+test('does not ignore async micro-tasks effect', async () => {
   const results = await measureRenders(<AsyncMicrotaskEffect />, { writeFile: false });
-  expect(results.issues.initialUpdateCount).toBe(0);
+  expect(results.issues.initialUpdateCount).toBe(1);
   expect(results.issues.redundantUpdates).toEqual([]);
 });
 

--- a/packages/measure/src/index.ts
+++ b/packages/measure/src/index.ts
@@ -2,7 +2,7 @@ export { configure, resetToDefaults } from './config';
 export { measureRenders, measurePerformance } from './measure-renders';
 export { measureFunction } from './measure-function';
 export { measureAsyncFunction } from './measure-async-function';
-export type { MeasureRendersOptions } from './measure-renders';
+export type { MeasureRendersOptions } from './measure-renders-common';
 export type { MeasureFunctionOptions } from './measure-function';
 export type { MeasureAsyncFunctionOptions } from './measure-async-function';
 export type { MeasureType, MeasureResults } from './types';

--- a/packages/measure/src/measure-renders-common.tsx
+++ b/packages/measure/src/measure-renders-common.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import * as logger from '@callstack/reassure-logger';
+import { config } from './config';
+import { RunResult, processRunResults } from './measure-helpers';
+import { showFlagsOutputIfNeeded } from './output';
+import { applyRenderPolyfills, revertRenderPolyfills } from './polyfills';
+import { ElementJsonTree, detectRedundantUpdates } from './redundant-renders';
+import { resolveTestingLibrary, getTestingLibrary } from './testing-library';
+import type { MeasureRendersResults } from './types';
+
+logger.configure({
+  verbose: process.env.REASSURE_VERBOSE === 'true' || process.env.REASSURE_VERBOSE === '1',
+  silent: process.env.REASSURE_SILENT === 'true' || process.env.REASSURE_SILENT === '1',
+});
+
+export interface MeasureRendersOptions {
+  runs?: number;
+  warmupRuns?: number;
+  removeOutliers?: boolean;
+  wrapper?: React.ComponentType<{ children: React.ReactElement }>;
+  scenario?: (screen: any) => Promise<any>;
+  writeFile?: boolean;
+  beforeEach?: () => Promise<void> | void;
+  afterEach?: () => Promise<void> | void;
+}
+
+export async function measureRendersInternal(
+  ui: React.ReactElement,
+  options?: MeasureRendersOptions
+): Promise<MeasureRendersResults> {
+  const runs = options?.runs ?? config.runs;
+  const scenario = options?.scenario;
+  const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
+  const removeOutliers = options?.removeOutliers ?? config.removeOutliers;
+
+  const { render, cleanup } = resolveTestingLibrary();
+  const testingLibrary = getTestingLibrary();
+
+  showFlagsOutputIfNeeded();
+  applyRenderPolyfills();
+
+  const runResults: RunResult[] = [];
+  const renderJsonTrees: ElementJsonTree[] = [];
+  let initialRenderCount = 0;
+
+  for (let iteration = 0; iteration < runs + warmupRuns; iteration += 1) {
+    await options?.beforeEach?.();
+
+    let duration = 0;
+    let count = 0;
+    let renderResult: any = null;
+
+    const captureRenderDetails = () => {
+      // We capture render details only on the first run
+      if (iteration !== 0) {
+        return;
+      }
+
+      // Initial render did not finish yet, so there is no "render" result yet and we cannot analyze the element tree.
+      if (renderResult == null) {
+        initialRenderCount += 1;
+        return;
+      }
+
+      if (testingLibrary === 'react-native') {
+        renderJsonTrees.push(renderResult.toJSON());
+      }
+    };
+
+    const handleRender = (_id: string, _phase: string, actualDuration: number) => {
+      duration += actualDuration;
+      count += 1;
+
+      captureRenderDetails();
+    };
+
+    const uiToRender = buildUiToRender(ui, handleRender, options?.wrapper);
+    renderResult = render(uiToRender);
+    captureRenderDetails();
+
+    if (scenario) {
+      await scenario(renderResult);
+    }
+
+    cleanup();
+    global.gc?.();
+
+    await options?.afterEach?.();
+
+    runResults.push({ duration, count });
+  }
+
+  revertRenderPolyfills();
+
+  return {
+    ...processRunResults(runResults, { warmupRuns, removeOutliers }),
+    issues: {
+      initialUpdateCount: initialRenderCount - 1,
+      redundantUpdates: detectRedundantUpdates(renderJsonTrees, initialRenderCount),
+    },
+  };
+}
+
+export function buildUiToRender(
+  ui: React.ReactElement,
+  onRender: React.ProfilerOnRenderCallback,
+  Wrapper?: React.ComponentType<{ children: React.ReactElement }>
+) {
+  const uiWithProfiler = (
+    <React.Profiler id="REASSURE_ROOT" onRender={onRender}>
+      {ui}
+    </React.Profiler>
+  );
+
+  return Wrapper ? <Wrapper>{uiWithProfiler}</Wrapper> : uiWithProfiler;
+}

--- a/packages/measure/src/measure-renders-native.tsx
+++ b/packages/measure/src/measure-renders-native.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as logger from '@callstack/reassure-logger';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { renderAsync, screen, cleanup } from '@testing-library/react-native';
 import { config } from './config';
 import { RunResult, processRunResults } from './measure-helpers';

--- a/packages/measure/src/measure-renders-native.tsx
+++ b/packages/measure/src/measure-renders-native.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import * as logger from '@callstack/reassure-logger';
+import { renderAsync, screen, cleanup } from '@testing-library/react-native';
+import { config } from './config';
+import { RunResult, processRunResults } from './measure-helpers';
+import { showFlagsOutputIfNeeded } from './output';
+import { applyRenderPolyfills, revertRenderPolyfills } from './polyfills';
+import { ElementJsonTree, detectRedundantUpdates } from './redundant-renders';
+import type { MeasureRendersResults } from './types';
+import { MeasureRendersOptions } from './measure-renders-common';
+
+logger.configure({
+  verbose: process.env.REASSURE_VERBOSE === 'true' || process.env.REASSURE_VERBOSE === '1',
+  silent: process.env.REASSURE_SILENT === 'true' || process.env.REASSURE_SILENT === '1',
+});
+
+export async function measureRendersNative(
+  ui: React.ReactElement,
+  options?: MeasureRendersOptions
+): Promise<MeasureRendersResults> {
+  const runs = options?.runs ?? config.runs;
+  const scenario = options?.scenario;
+  const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
+  const removeOutliers = options?.removeOutliers ?? config.removeOutliers;
+
+  showFlagsOutputIfNeeded();
+  applyRenderPolyfills();
+
+  const runResults: RunResult[] = [];
+  const renderJsonTrees: ElementJsonTree[] = [];
+  let initialRenderCount = 0;
+
+  for (let iteration = 0; iteration < runs + warmupRuns; iteration += 1) {
+    await options?.beforeEach?.();
+
+    let duration = 0;
+    let count = 0;
+    let renderResult: any = null;
+
+    const captureRenderDetails = () => {
+      // We capture render details only on the first run
+      if (iteration !== 0) {
+        return;
+      }
+
+      // Initial render did not finish yet, so there is no "render" result yet and we cannot analyze the element tree.
+      if (renderResult == null) {
+        initialRenderCount += 1;
+        return;
+      }
+
+      renderJsonTrees.push(renderResult.toJSON());
+    };
+
+    const handleRender = (_id: string, _phase: string, actualDuration: number) => {
+      duration += actualDuration;
+      count += 1;
+
+      captureRenderDetails();
+    };
+
+    const uiToRender = buildUiToRender(ui, handleRender, options?.wrapper);
+    renderResult = await renderAsync(uiToRender);
+    captureRenderDetails();
+
+    if (scenario) {
+      await scenario(renderResult);
+    }
+
+    await screen.unmountAsync();
+    cleanup();
+    global.gc?.();
+
+    await options?.afterEach?.();
+
+    runResults.push({ duration, count });
+  }
+
+  revertRenderPolyfills();
+
+  return {
+    ...processRunResults(runResults, { warmupRuns, removeOutliers }),
+    issues: {
+      initialUpdateCount: initialRenderCount - 1,
+      redundantUpdates: detectRedundantUpdates(renderJsonTrees, initialRenderCount),
+    },
+  };
+}
+
+export function buildUiToRender(
+  ui: React.ReactElement,
+  onRender: React.ProfilerOnRenderCallback,
+  Wrapper?: React.ComponentType<{ children: React.ReactElement }>
+) {
+  const uiWithProfiler = (
+    <React.Profiler id="REASSURE_ROOT" onRender={onRender}>
+      {ui}
+    </React.Profiler>
+  );
+
+  return Wrapper ? <Wrapper>{uiWithProfiler}</Wrapper> : uiWithProfiler;
+}

--- a/packages/measure/src/measure-renders.tsx
+++ b/packages/measure/src/measure-renders.tsx
@@ -1,34 +1,20 @@
-import * as React from 'react';
 import * as logger from '@callstack/reassure-logger';
-import { config } from './config';
-import { RunResult, processRunResults } from './measure-helpers';
-import { showFlagsOutputIfNeeded, writeTestStats } from './output';
-import { applyRenderPolyfills, revertRenderPolyfills } from './polyfills';
-import { ElementJsonTree, detectRedundantUpdates } from './redundant-renders';
-import { resolveTestingLibrary, getTestingLibrary } from './testing-library';
-import type { MeasureRendersResults } from './types';
-
-logger.configure({
-  verbose: process.env.REASSURE_VERBOSE === 'true' || process.env.REASSURE_VERBOSE === '1',
-  silent: process.env.REASSURE_SILENT === 'true' || process.env.REASSURE_SILENT === '1',
-});
-
-export interface MeasureRendersOptions {
-  runs?: number;
-  warmupRuns?: number;
-  removeOutliers?: boolean;
-  wrapper?: React.ComponentType<{ children: React.ReactElement }>;
-  scenario?: (screen: any) => Promise<any>;
-  writeFile?: boolean;
-  beforeEach?: () => Promise<void> | void;
-  afterEach?: () => Promise<void> | void;
-}
+import { measureRendersInternal, MeasureRendersOptions } from './measure-renders-common';
+import { measureRendersNative } from './measure-renders-native';
+import { writeTestStats } from './output';
+import { getTestingLibrary } from './testing-library';
+import { MeasureRendersResults } from './types';
 
 export async function measureRenders(
   ui: React.ReactElement,
   options?: MeasureRendersOptions
 ): Promise<MeasureRendersResults> {
-  const stats = await measureRendersInternal(ui, options);
+  let stats: MeasureRendersResults;
+  if (getTestingLibrary() === 'react-native') {
+    stats = await measureRendersNative(ui, options);
+  } else {
+    stats = await measureRendersInternal(ui, options);
+  }
 
   if (options?.writeFile !== false) {
     await writeTestStats(stats, 'render');
@@ -49,95 +35,4 @@ export async function measurePerformance(
   );
 
   return await measureRenders(ui, options);
-}
-
-async function measureRendersInternal(
-  ui: React.ReactElement,
-  options?: MeasureRendersOptions
-): Promise<MeasureRendersResults> {
-  const runs = options?.runs ?? config.runs;
-  const scenario = options?.scenario;
-  const warmupRuns = options?.warmupRuns ?? config.warmupRuns;
-  const removeOutliers = options?.removeOutliers ?? config.removeOutliers;
-
-  const { render, cleanup } = resolveTestingLibrary();
-  const testingLibrary = getTestingLibrary();
-
-  showFlagsOutputIfNeeded();
-  applyRenderPolyfills();
-
-  const runResults: RunResult[] = [];
-  const renderJsonTrees: ElementJsonTree[] = [];
-  let initialRenderCount = 0;
-
-  for (let iteration = 0; iteration < runs + warmupRuns; iteration += 1) {
-    await options?.beforeEach?.();
-
-    let duration = 0;
-    let count = 0;
-    let renderResult: any = null;
-
-    const captureRenderDetails = () => {
-      // We capture render details only on the first run
-      if (iteration !== 0) {
-        return;
-      }
-
-      // Initial render did not finish yet, so there is no "render" result yet and we cannot analyze the element tree.
-      if (renderResult == null) {
-        initialRenderCount += 1;
-        return;
-      }
-
-      if (testingLibrary === 'react-native') {
-        renderJsonTrees.push(renderResult.toJSON());
-      }
-    };
-
-    const handleRender = (_id: string, _phase: string, actualDuration: number) => {
-      duration += actualDuration;
-      count += 1;
-
-      captureRenderDetails();
-    };
-
-    const uiToRender = buildUiToRender(ui, handleRender, options?.wrapper);
-    renderResult = render(uiToRender);
-    captureRenderDetails();
-
-    if (scenario) {
-      await scenario(renderResult);
-    }
-
-    cleanup();
-    global.gc?.();
-
-    await options?.afterEach?.();
-
-    runResults.push({ duration, count });
-  }
-
-  revertRenderPolyfills();
-
-  return {
-    ...processRunResults(runResults, { warmupRuns, removeOutliers }),
-    issues: {
-      initialUpdateCount: initialRenderCount - 1,
-      redundantUpdates: detectRedundantUpdates(renderJsonTrees, initialRenderCount),
-    },
-  };
-}
-
-export function buildUiToRender(
-  ui: React.ReactElement,
-  onRender: React.ProfilerOnRenderCallback,
-  Wrapper?: React.ComponentType<{ children: React.ReactElement }>
-) {
-  const uiWithProfiler = (
-    <React.Profiler id="REASSURE_ROOT" onRender={onRender}>
-      {ui}
-    </React.Profiler>
-  );
-
-  return Wrapper ? <Wrapper>{uiWithProfiler}</Wrapper> : uiWithProfiler;
 }

--- a/test-apps/native/package.json
+++ b/test-apps/native/package.json
@@ -24,7 +24,7 @@
     "@react-native/eslint-config": "0.78.0",
     "@react-native/metro-config": "0.78.0",
     "@react-native/typescript-config": "0.78.0",
-    "@testing-library/react-native": "^13.2.0",
+    "@testing-library/react-native": "^13.3.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.0.0",
     "@types/react-test-renderer": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,26 +3409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-native@npm:^13.2.0":
-  version: 13.2.0
-  resolution: "@testing-library/react-native@npm:13.2.0"
-  dependencies:
-    chalk: "npm:^4.1.2"
-    jest-matcher-utils: "npm:^29.7.0"
-    pretty-format: "npm:^29.7.0"
-    redent: "npm:^3.0.0"
-  peerDependencies:
-    jest: ">=29.0.0"
-    react: ">=18.2.0"
-    react-native: ">=0.71"
-    react-test-renderer: ">=18.2.0"
-  peerDependenciesMeta:
-    jest:
-      optional: true
-  checksum: 10c0/5ed8e09f82f45c057f12a716008f31abf934e6a3d84955540e2ab96d7534c82b9afdb0af050e986d8b63ae9dd8272f8a752c45ecb847a11e7549f30de3d84427
-  languageName: node
-  linkType: hard
-
 "@testing-library/react-native@npm:^13.3.0":
   version: 13.3.2
   resolution: "@testing-library/react-native@npm:13.3.2"
@@ -5728,13 +5708,6 @@ __metadata:
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: 10c0/c38cfc8eeb9fda09febb44bcd85e467c970d4e3bf526095394e5a4f18bc26dd0cf6b22c69c1fa9969261521c593836db335c2795218f6d781a512aea2fb8209d
-  languageName: node
-  linkType: hard
-
-"diff-sequences@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "diff-sequences@npm:29.6.3"
-  checksum: 10c0/32e27ac7dbffdf2fb0eb5a84efd98a9ad084fbabd5ac9abb8757c6770d5320d2acd172830b28c4add29bb873d59420601dfc805ac4064330ce59b1adfd0593b2
   languageName: node
   linkType: hard
 
@@ -8315,18 +8288,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-diff@npm:29.7.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    diff-sequences: "npm:^29.6.3"
-    jest-get-type: "npm:^29.6.3"
-    pretty-format: "npm:^29.7.0"
-  checksum: 10c0/89a4a7f182590f56f526443dde69acefb1f2f0c9e59253c61d319569856c4931eae66b8a3790c443f529267a0ddba5ba80431c585deed81827032b2b2a1fc999
-  languageName: node
-  linkType: hard
-
 "jest-docblock@npm:30.0.1":
   version: 30.0.1
   resolution: "jest-docblock@npm:30.0.1"
@@ -8449,18 +8410,6 @@ __metadata:
     jest-diff: "npm:30.0.2"
     pretty-format: "npm:30.0.2"
   checksum: 10c0/6e862dfe259c30f066fe800cc302cad8cdb4ff92dad73538ce099960ecffd5ba119282af933521765ce24fb3d99b5338d7fa64261df08f9e8505350e9d112424
-  languageName: node
-  linkType: hard
-
-"jest-matcher-utils@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-matcher-utils@npm:29.7.0"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    jest-diff: "npm:^29.7.0"
-    jest-get-type: "npm:^29.6.3"
-    pretty-format: "npm:^29.7.0"
-  checksum: 10c0/0d0e70b28fa5c7d4dce701dc1f46ae0922102aadc24ed45d594dd9b7ae0a8a6ef8b216718d1ab79e451291217e05d4d49a82666e1a3cc2b428b75cd9c933244e
   languageName: node
   linkType: hard
 
@@ -11038,7 +10987,7 @@ __metadata:
     "@react-native/eslint-config": "npm:0.78.0"
     "@react-native/metro-config": "npm:0.78.0"
     "@react-native/typescript-config": "npm:0.78.0"
-    "@testing-library/react-native": "npm:^13.2.0"
+    "@testing-library/react-native": "npm:^13.3.0"
     "@types/jest": "npm:^30.0.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-test-renderer": "npm:^19.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,7 +1643,7 @@ __metadata:
     "@callstack/reassure-logger": "npm:1.4.0"
     "@relmify/jest-serializer-strip-ansi": "npm:^1.0.2"
     "@testing-library/react": "npm:^16.2.0"
-    "@testing-library/react-native": "npm:^13.2.0"
+    "@testing-library/react-native": "npm:^13.3.0"
     "@types/jest": "npm:^30.0.0"
     "@types/react": "npm:^19.0.0"
     babel-jest: "npm:^30.0.2"
@@ -1659,7 +1659,11 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     typescript: "npm:^5.8.2"
   peerDependencies:
+    "@react-native/testing-library": ^13.3.0
     react: ">=18.0.0"
+  peerDependenciesMeta:
+    "@react-native/testing-library":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2314,6 +2318,15 @@ __metadata:
   dependencies:
     "@sinclair/typebox": "npm:^0.34.0"
   checksum: 10c0/27977359edc4b33293af7c85c53de5014a87c29b9ab98b0a827fedfc6635abdb522aad8c3ff276080080911f519699b094bd6f4e151b43f0cc5856ccc83c04a7
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:30.0.5":
+  version: 30.0.5
+  resolution: "@jest/schemas@npm:30.0.5"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10c0/449dcd7ec5c6505e9ac3169d1143937e67044ae3e66a729ce4baf31812dfd30535f2b3b2934393c97cfdf5984ff581120e6b38f62b8560c8b5b7cc07f4175f65
   languageName: node
   linkType: hard
 
@@ -3413,6 +3426,26 @@ __metadata:
     jest:
       optional: true
   checksum: 10c0/5ed8e09f82f45c057f12a716008f31abf934e6a3d84955540e2ab96d7534c82b9afdb0af050e986d8b63ae9dd8272f8a752c45ecb847a11e7549f30de3d84427
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-native@npm:^13.3.0":
+  version: 13.3.2
+  resolution: "@testing-library/react-native@npm:13.3.2"
+  dependencies:
+    jest-matcher-utils: "npm:^30.0.5"
+    picocolors: "npm:^1.1.1"
+    pretty-format: "npm:^30.0.5"
+    redent: "npm:^3.0.0"
+  peerDependencies:
+    jest: ">=29.0.0"
+    react: ">=18.2.0"
+    react-native: ">=0.71"
+    react-test-renderer: ">=18.2.0"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 10c0/c76baefa200183aa79e45d672370061a7ff8bdb8b45c02fd83c903604c265bae2d4ca194ddb71c90646cc2649eaf0d6e6ffc1ea375823d96e81635423b51e024
   languageName: node
   linkType: hard
 
@@ -8270,6 +8303,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:30.0.5":
+  version: 30.0.5
+  resolution: "jest-diff@npm:30.0.5"
+  dependencies:
+    "@jest/diff-sequences": "npm:30.0.1"
+    "@jest/get-type": "npm:30.0.1"
+    chalk: "npm:^4.1.2"
+    pretty-format: "npm:30.0.5"
+  checksum: 10c0/b218ced37b7676f578ea866762f04caa74901bdcf3f593872aa9a4991a586302651a1d16bb0386772adacc7580a452ec621359af75d733c0b50ea947fe1881d3
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
@@ -8416,6 +8461,18 @@ __metadata:
     jest-get-type: "npm:^29.6.3"
     pretty-format: "npm:^29.7.0"
   checksum: 10c0/0d0e70b28fa5c7d4dce701dc1f46ae0922102aadc24ed45d594dd9b7ae0a8a6ef8b216718d1ab79e451291217e05d4d49a82666e1a3cc2b428b75cd9c933244e
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^30.0.5":
+  version: 30.0.5
+  resolution: "jest-matcher-utils@npm:30.0.5"
+  dependencies:
+    "@jest/get-type": "npm:30.0.1"
+    chalk: "npm:^4.1.2"
+    jest-diff: "npm:30.0.5"
+    pretty-format: "npm:30.0.5"
+  checksum: 10c0/231d891b29bfc218f2f5739c10873b6671426e31ad1c5538eed1531e62608fd3f60d32f41821332a6cf41f1614fd37361434c754fdd49c849b35ef2e5156c02e
   languageName: node
   linkType: hard
 
@@ -10588,6 +10645,17 @@ __metadata:
     ansi-styles: "npm:^5.2.0"
     react-is: "npm:^18.3.1"
   checksum: 10c0/cf542dc2d0be95e2b1c6e3a397a4fc13fce1c9f8feed6b56165c0d23c7a83423abb6b032ed8e3e1b7c1c0709f9b117dd30b5185f107e58f8766616be6de84850
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:30.0.5, pretty-format@npm:^30.0.5":
+  version: 30.0.5
+  resolution: "pretty-format@npm:30.0.5"
+  dependencies:
+    "@jest/schemas": "npm:30.0.5"
+    ansi-styles: "npm:^5.2.0"
+    react-is: "npm:^18.3.1"
+  checksum: 10c0/9f6cf1af5c3169093866c80adbfdad32f69c692b62f24ba3ca8cdec8519336123323f896396f9fa40346a41b197c5f6be15aec4d8620819f12496afaaca93f81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Use `renderAsync` when rendering for RN.

ToDo:
- [ ] Resolve linting errors
- [ ] Fallback to sync render if `renderAsync` not available (older RNTL version)
- [ ] Assess perf test stability

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
