### PR TITLE
chore: bump simple-git to v3.32.3

### DIFF
--- a/.changeset/neat-moons-leave.md
+++ b/.changeset/neat-moons-leave.md
@@ -1,0 +1,5 @@
+---
+'@callstack/reassure-cli': patch
+---
+
+bump simple-git

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "@callstack/reassure-compare": "1.4.0",
     "@callstack/reassure-logger": "1.4.0",
     "chalk": "4.1.2",
-    "simple-git": "^3.30.0",
+    "simple-git": "^3.32.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,7 +1573,7 @@ __metadata:
     jest: "npm:^30.2.0"
     prettier: "npm:^3.6.2"
     react-native-builder-bob: "npm:^0.24.0"
-    simple-git: "npm:^3.30.0"
+    simple-git: "npm:^3.32.3"
     typescript: "npm:^5.9.3"
     yargs: "npm:^17.7.2"
   bin:
@@ -10902,14 +10902,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.30.0":
-  version: 3.30.0
-  resolution: "simple-git@npm:3.30.0"
+"simple-git@npm:^3.32.3":
+  version: 3.32.3
+  resolution: "simple-git@npm:3.32.3"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
     debug: "npm:^4.4.0"
-  checksum: 10c0/ca123580944d55c7f93d17f7a89b39cd43245916b35ed3a8b1269d1f2ae9200e17f098e42af4a2572313726f1273641cbe0748a1ea37d8c803c181fb69068b1d
+  checksum: 10c0/b08ad0811b82d69a9b150109cbf29247bc13f8d5fb5380dcb834a5e0467124c3b5a41a2b9a5dd3c16f1edc9af7fae9add5182ac6476ef0d50e2341c7820fa0f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

This PR fixes a CRITICAL vulnerability for `simple-git` by updating it to `v3.32.3`. 

Advisory - https://github.com/advisories/GHSA-r275-fr43-pm7q

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

- Verified Locally
- CI Passes

![reassure](https://github.com/user-attachments/assets/0091eb35-a109-4bd5-b6ce-9865f8f3f42d)

